### PR TITLE
Enable vscode development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@
 source 'https://rubygems.org'
 gem 'fastlane'
 gem 'cocoapods'
+gem 'xcodeproj'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods
   fastlane
+  xcodeproj
 
 BUNDLED WITH
    1.14.6

--- a/scripts/vscode-helper.rb
+++ b/scripts/vscode-helper.rb
@@ -1,0 +1,36 @@
+## Ruby script that allows local development without Xcode and even mac.
+## Script will add and append all new files to Xcode project
+## After that changes can be build using CircleCi 
+
+## Based on https://github.com/CocoaPods/Xcodeproj/issues/178
+
+require 'xcodeproj'
+
+def addfiles (direc, current_group, main_target)
+    Dir.glob(direc) do |item|
+        next if item == '.' or item == '.DS_Store'
+
+                if File.directory?(item)
+            new_folder = File.basename(item)
+            created_group = current_group.new_group(new_folder)
+            addfiles("#{item}/*", created_group, main_target)
+        else 
+          i = current_group.new_file(item)
+          if item.include? ".swift"
+              main_target.add_file_references([i])
+          end
+        end
+    end
+end
+
+project_path = './example/AeroGearSdkExample.xcodeproj'
+project = Xcodeproj::Project.open(project_path)
+
+default_group = project.new_group('default')
+
+mainPath = './example'
+main_target = project.targets.first
+
+addfiles("#{mainPath}/*", default_group, main_target)
+
+project.save(project_path)

--- a/scripts/vscode-helper.rb
+++ b/scripts/vscode-helper.rb
@@ -2,6 +2,9 @@
 ## Script will add and append all new files to Xcode project
 ## After that changes can be build using CircleCi 
 
+## Running script
+## bundle exec ruby ./scripts/vscode-helper.rb 
+
 ## Based on https://github.com/CocoaPods/Xcodeproj/issues/178
 
 require 'xcodeproj'


### PR DESCRIPTION
### Motivation

Enable running and developing swift based applications without running Xcode and Mac operating system. This aproach can be used to create and edit existing files. Produce and run unit tests etc.