### PR TITLE
Network request wrapper

### DIFF
--- a/AeroGearServices.podspec
+++ b/AeroGearServices.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.subspec 'core' do |base|
     base.source_files = 'modules/core/**/*.swift'
     base.frameworks   = 'UIKit', 'Foundation', 'SystemConfiguration'
-    base.dependency 'AeroGearHttp'
+    base.dependency 'Alamofire', '4.6.0'
     base.dependency 'XCGLogger'
   end
 end

--- a/docs/core/README.adoc
+++ b/docs/core/README.adoc
@@ -39,8 +39,7 @@ Wrapper by default works with popular AlamoFire Swift library.
 
 [source,swift]
 ----
- coreInstance.getHttp()
-    http.getHttp().get(uri, { (response, error) -> Void in
+ coreInstance.getHttp().get(uri, { (response, error) -> Void in
         if let error = error {
             AgsCore.logger.error("An error has occurred during read! \(error)")
             return

--- a/docs/core/README.adoc
+++ b/docs/core/README.adoc
@@ -30,3 +30,5 @@ End users can change or disable logger in top level application by providing emp
  AgsCore.setLogger(AgsLoggable())
 ----
  
+=== Network library
+

--- a/docs/core/README.adoc
+++ b/docs/core/README.adoc
@@ -32,3 +32,23 @@ End users can change or disable logger in top level application by providing emp
  
 === Network library
 
+Network library offers common wrapper for making any networking requests.
+Wrapper by default works with popular AlamoFire Swift library.
+
+==== Usage
+
+[source,swift]
+----
+ coreInstance.getHttp()
+    http.getHttp().get(uri, { (response, error) -> Void in
+        if let error = error {
+            AgsCore.logger.error("An error has occurred during read! \(error)")
+            return
+        }
+        // Unwrap optional
+        if let response = response as? [String: Any] {
+            // Operate on response Dictionary
+            print(response)
+        }
+    })
+----

--- a/docs/service-guide.adoc
+++ b/docs/service-guide.adoc
@@ -99,3 +99,18 @@ open ./example/AeroGearSdkExample.xcworkspace
 
 Example application source code is grouped in `AeroGearSdkExample` folder
 SDK source code is grouped in `Pods` > `Development pods` folder
+
+=== Troubleshooting 
+
+==== XCode is missing files
+
+When switching between branches XCode will not be able to recognize the changes.
+This may be often seen as compilation errors when file is missing.
+
+To fix this problem developer need to:
+
+1. Close Xcode
+2. Run `pod install`
+3. Reopen project again
+
+> Note: Please make sure that cocoapods contains latest index before running pod install

--- a/example/AeroGearSdkExample.xcodeproj/project.pbxproj
+++ b/example/AeroGearSdkExample.xcodeproj/project.pbxproj
@@ -261,14 +261,14 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-AeroGearSdkExample/Pods-AeroGearSdkExample-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/AGSCore/AGSCore.framework",
-				"${BUILT_PRODUCTS_DIR}/AeroGearHttp/AeroGearHttp.framework",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/ObjcExceptionBridging/ObjcExceptionBridging.framework",
 				"${BUILT_PRODUCTS_DIR}/XCGLogger/XCGLogger.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AGSCore.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AeroGearHttp.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjcExceptionBridging.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/XCGLogger.framework",
 			);

--- a/example/AeroGearSdkExample/ViewController.swift
+++ b/example/AeroGearSdkExample/ViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController, UIPickerViewDataSource, UIPickerViewDele
             let http = coreInstance.getHttp()
             http.getHttp().get(uri, { (response, error) -> Void in
                 if let error = error {
-                    print("An error has occured during read! \(error)")
+                    print("An error has occurred during read! \(error)")
                     return
                 }
                 if let response = response as? [String: Any] {

--- a/example/AeroGearSdkExample/ViewController.swift
+++ b/example/AeroGearSdkExample/ViewController.swift
@@ -22,10 +22,9 @@ class ViewController: UIViewController, UIPickerViewDataSource, UIPickerViewDele
 
     @IBAction func buttonClick(sender _: UIButton) {
         if let uri = currentConfig?.config?.uri {
-            let http = coreInstance.getHttp()
-            http.getHttp().get(uri, { (response, error) -> Void in
+            coreInstance.getHttp().get(uri, { (response, error) -> Void in
                 if let error = error {
-                    print("An error has occurred during read! \(error)")
+                    AgsCore.logger.error("An error has occurred during read! \(error)")
                     return
                 }
                 if let response = response as? [String: Any] {

--- a/example/AeroGearSdkExample/ViewController.swift
+++ b/example/AeroGearSdkExample/ViewController.swift
@@ -17,14 +17,15 @@ class ViewController: UIViewController, UIPickerViewDataSource, UIPickerViewDele
     let coreInstance = AgsCore()
     var currentConfig: MobileService?
 
+
     var pickerDataSource = ["sync", "prometheus", "echo"]
 
     @IBAction func buttonClick(sender _: UIButton) {
         if let uri = currentConfig?.config?.uri {
             let http = coreInstance.getHttp()
-            http.getHttp().request(method: .post, path: uri, completionHandler: { (response, error) -> Void in
-                if error != nil {
-                    print("An error has occured during read! \(error!)")
+            http.getHttp().get(uri, { (response, error) -> Void in
+                if let error = error {
+                    print("An error has occured during read! \(error)")
                     return
                 }
                 if let response = response as? [String: Any] {
@@ -59,7 +60,8 @@ class ViewController: UIViewController, UIPickerViewDataSource, UIPickerViewDele
     }
 
     func pickerView(_: UIPickerView, didSelectRow row: Int, inComponent _: Int) {
-        AgsCore.logger.debug("Loading configuration")
+
+        AgsCore.logger.info("Loading configuration")
         currentConfig = coreInstance.getConfiguration(pickerDataSource[row])
         let jsonEncoder = JSONEncoder()
         do {

--- a/modules/core/AgsCore.swift
+++ b/modules/core/AgsCore.swift
@@ -30,8 +30,8 @@ public class AgsCore {
      * @param
      * @return instance of network interface
      */
-    public func getHttp() -> AgsHttp {
-        return http
+    public func getHttp() -> AgsHttpRequest {
+        return http.getHttp()
     }
 
     /**

--- a/modules/core/AgsCore.swift
+++ b/modules/core/AgsCore.swift
@@ -1,4 +1,3 @@
-import AeroGearHttp
 import Foundation
 import XCGLogger
 

--- a/modules/core/agscore.podspec
+++ b/modules/core/agscore.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
                      :tag => s.version}
   s.source_files = '**/*.swift'
   s.frameworks   = 'UIKit', 'Foundation', 'SystemConfiguration'
-  s.dependency 'AeroGearHttp'
+  s.dependency 'Alamofire', '4.6.0'
   s.dependency 'XCGLogger'
   s.requires_arc = true
 end

--- a/modules/core/http/AgsHttp.swift
+++ b/modules/core/http/AgsHttp.swift
@@ -1,4 +1,3 @@
-import AeroGearHttp
 import Foundation
 
 public protocol Request {
@@ -9,22 +8,15 @@ public protocol Request {
  */
 public class AgsHttp {
 
-    let defaultHttp = Http()
+    let defaultHttp = AgsHttpRequest()
 
     public init() {
     }
 
     /**
-     * Return new Http instance for specific service
-     */
-    public func getHttp(service: MobileService) -> Http {
-        return Http(baseURL: service.config?.uri)
-    }
-
-    /**
      * Return shared Http instance
      */
-    public func getHttp() -> Http {
+    public func getHttp() -> AgsHttpRequest {
         return defaultHttp
     }
 }

--- a/modules/core/http/AgsHttp.swift
+++ b/modules/core/http/AgsHttp.swift
@@ -1,8 +1,5 @@
 import Foundation
 
-public protocol Request {
-}
-
 /**
  * Wrapper class used for network requests
  */

--- a/modules/core/http/AgsHttpRequest.swift
+++ b/modules/core/http/AgsHttpRequest.swift
@@ -1,0 +1,56 @@
+import Alamofire
+import Foundation
+
+/**
+ * This is a implementation of HttpRequest based on AlamoFire
+ * Implementation is designed to work with Json payload
+ */
+public class AgsHttpRequest {
+
+    public func get(_ url: String, params: [String: AnyObject]? = [:], headers: [String: String]? = [:],
+                    _ handler : @escaping (Any?, Error?) -> Void) {
+        Alamofire.request(url, parameters: params, headers: headers).responseJSON { (responseObject) -> Void in
+            if responseObject.result.isSuccess {
+                handler(responseObject.result.value, nil)
+            }
+            if responseObject.result.isFailure {
+                handler(nil, responseObject.result.error)
+            }
+        }
+    }
+
+    public func post(_ url: String, body: [String: AnyObject]? = [:], headers: [String: String]? = [:], _ handler: @escaping (Any?, Error?) -> Void) {
+        Alamofire.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: headers).responseJSON { (responseObject) -> Void in
+            if responseObject.result.isSuccess {
+                handler(responseObject.result.value, nil)
+            }
+            if responseObject.result.isFailure {
+                handler(nil, responseObject.result.error)
+            }
+        }
+    }
+
+    public func put(_ url: String, body: [String: AnyObject]? = [:], headers: [String: String]? = [:], _ handler: @escaping (Any?, Error?) -> Void) {
+        Alamofire.request(url, method: .put, parameters: body, encoding: JSONEncoding.default, headers: headers).responseJSON { (responseObject) -> Void in
+
+            if responseObject.result.isSuccess {
+                handler(responseObject.result.value, nil)
+            }
+            if responseObject.result.isFailure {
+                handler(nil, responseObject.result.error)
+            }
+        }
+    }
+
+    public func delete(_ url: String, headers: [String: String]? = [:], _ handler: @escaping (Any?, Error?) -> Void) {
+        Alamofire.request(url, method: .delete, encoding: JSONEncoding.default, headers: headers).responseJSON { (responseObject) -> Void in
+
+            if responseObject.result.isSuccess {
+                handler(responseObject.result.value, nil)
+            }
+            if responseObject.result.isFailure {
+                handler(nil, responseObject.result.error)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Remove AeroGearHttp as we still do not know how this will be maintained.
Use alamofire for dependency management.
Provide simple wrapper for http api. 
Wrapper was simplified as Alamofire provides many extensible options and we are not sure what may be required at the moment. 
We could extend that over the time basing on what our SDK's will need.

#### Notes

It was not possible to keep similar api for android as Android implementation it's not using lambdas. 
As lambdas are TODO for Android it's best to align Android implementation to IOS. 