### PR TITLE
 📝  make sure `pod install` is executed first before opening the xcode

### DIFF
--- a/docs/service-guide.adoc
+++ b/docs/service-guide.adoc
@@ -98,7 +98,9 @@ SDK and example applications can be developed in XCode.
 To open xcode project Execute
 
 ----
-open ./example/AeroGearSdkExample.xcworkspace
+cd ./example
+pod install
+open ./AeroGearSdkExample.xcworkspace
 ----
 
 Example application source code is grouped in `AeroGearSdkExample` folder


### PR DESCRIPTION
 project

### Motivation

By default the `AeroGearSdkExample.xcworkspace` doesn't exist In the repo.  Developers need to run `pod install` first

### Description

Update the instructions to make it clear that `pod install` needs to be executed first

### Progress

- [x] Update instruction