### PR TITLE
Update metrics payload

### DIFF
--- a/modules/core/metrics/AgsMetrics.swift
+++ b/modules/core/metrics/AgsMetrics.swift
@@ -59,14 +59,15 @@ open class AgsMetrics: MetricsPublishable {
             let result = metric.collect()
             payload[metric.identifier] = result
         }
-        payload = metricsRoot().merging(payload) { orig, _ in orig }
-        publisher.publish(payload)
+        publisher.publish(appendToRootMetrics(payload))
     }
 
-    private func metricsRoot() -> [String: Any] {
+    private func appendToRootMetrics(_ payload: MetricsData) -> [String: Any] {
         return [
             "clientId": appData.clientId,
             "timestamp": Int(NSDate().timeIntervalSince1970 * 1000),
+            "data": payload
         ]
     }
+
 }


### PR DESCRIPTION
Related issues: 

* [AGIOS-664](https://issues.jboss.org/browse/AGIOS-664) - iOS metrics payload is missing the property 'data'

**Before**

```
2018-02-27 14:44:23.990 [Debug] [MetricsNetworkPublisher.swift:18] publish > Sending metrics ["timestamp": 1519753463989, "device": ["platformVersion": "11.2", "platform": "ios", "device": "iPhone"], "clientId": 9EDD6D9A-1282-4F3F-ADE6-34E79C3D75D2, "app": ["appVersion": 1.0, "sdkVersion": "DEVELOPMENT", "appId": org.aerogear.AeroGearSdkExample]]
```

**After**
```
2018-02-27 14:55:07.956 [Debug] [MetricsNetworkPublisher.swift:18] publish > Sending metrics ["timestamp": 1519754107955, "clientId": 9EDD6D9A-1282-4F3F-ADE6-34E79C3D75D2, "data": ["device": ["platformVersion": "11.2", "platform": "ios", "device": "iPhone"], "app": ["appVersion": 1.0, "sdkVersion": "DEVELOPMENT", "appId": org.aerogear.AeroGearSdkExample]]]
```
