### PR TITLE
AEROGEAR-2092 Add OIDCCredentials implementation

### DIFF
--- a/example/AeroGearSdkExample.xcodeproj/project.pbxproj
+++ b/example/AeroGearSdkExample.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		018FBE77201257F300E763A5 /* mobile-services.json in Resources */ = {isa = PBXBuildFile; fileRef = 018FBE75201257F300E763A5 /* mobile-services.json */; };
 		01928B8A201F202D0053EEB0 /* ConfigParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6372266C9F61265244A81632 /* ConfigParserTests.swift */; };
 		4436E282BDD390473AD840EE /* Pods_AeroGearSdkExampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0126BB257CFC9A2A188E6B84 /* Pods_AeroGearSdkExampleTests.framework */; };
-		659F2EDBD50348EBB799D1EF /* MetricsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 659F2A7D4D01A03C0143073E /* MetricsServiceTests.swift */; };
 		8DB04C4CC96666E5C481162F /* Pods_AeroGearSdkExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D7E51B1D502165078E140C8B /* Pods_AeroGearSdkExample.framework */; };
 		B352664D204437DE004BACC7 /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B352664B204437DE004BACC7 /* BaseViewController.swift */; };
 		B352664E204437DE004BACC7 /* MenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B352664C204437DE004BACC7 /* MenuViewController.swift */; };
@@ -34,6 +33,8 @@
 		B3AC1A89204825EC00BEB12B /* MockHttpRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AC1A88204825EC00BEB12B /* MockHttpRequest.swift */; };
 		B3AC1A8B2049951900BEB12B /* MobileServiceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AC1A8A2049951900BEB12B /* MobileServiceTest.swift */; };
 		B3AC1A8D2049E11900BEB12B /* UsersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3AC1A8C2049E11900BEB12B /* UsersTests.swift */; };
+		EF85064F204D4B5C008033AD /* OIDCCredentialsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF85064E204D4B5C008033AD /* OIDCCredentialsTest.swift */; };
+		EF850651204D6D45008033AD /* CredentialsManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF850650204D6D45008033AD /* CredentialsManagerTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +82,8 @@
 		B3AC1A8C2049E11900BEB12B /* UsersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsersTests.swift; sourceTree = "<group>"; };
 		BF3FA3B26CCABCDADAC6AB94 /* Pods-AeroGearSdkExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AeroGearSdkExampleTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-AeroGearSdkExampleTests/Pods-AeroGearSdkExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		D7E51B1D502165078E140C8B /* Pods_AeroGearSdkExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AeroGearSdkExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF85064E204D4B5C008033AD /* OIDCCredentialsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OIDCCredentialsTest.swift; sourceTree = "<group>"; };
+		EF850650204D6D45008033AD /* CredentialsManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsManagerTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -224,6 +227,7 @@
 		B3AC1A81204815E000BEB12B /* auth */ = {
 			isa = PBXGroup;
 			children = (
+				EF85064D204D4B0A008033AD /* credentials */,
 				B3AC1A84204815E700BEB12B /* authenticator */,
 				B3AC1A82204815E000BEB12B /* AuthTests.swift */,
 				B3AC1A8C2049E11900BEB12B /* UsersTests.swift */,
@@ -245,6 +249,15 @@
 				B3AC1A88204825EC00BEB12B /* MockHttpRequest.swift */,
 			);
 			path = mocks;
+			sourceTree = "<group>";
+		};
+		EF85064D204D4B0A008033AD /* credentials */ = {
+			isa = PBXGroup;
+			children = (
+				EF85064E204D4B5C008033AD /* OIDCCredentialsTest.swift */,
+				EF850650204D6D45008033AD /* CredentialsManagerTest.swift */,
+			);
+			path = credentials;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -304,6 +317,11 @@
 					018FBE5120123AEE00E763A5 = {
 						CreatedOnToolsVersion = 9.2;
 						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.Keychain = {
+								enabled = 0;
+							};
+						};
 					};
 					018FBE6520123AEE00E763A5 = {
 						CreatedOnToolsVersion = 9.2;
@@ -369,6 +387,7 @@
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/AppAuth/AppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/ObjcExceptionBridging/ObjcExceptionBridging.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftKeychainWrapper/SwiftKeychainWrapper.framework",
 				"${BUILT_PRODUCTS_DIR}/XCGLogger/XCGLogger.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -378,6 +397,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ObjcExceptionBridging.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftKeychainWrapper.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/XCGLogger.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -489,6 +509,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3AC1A862048184600BEB12B /* OIDCAuthenticatorTest.swift in Sources */,
+				EF85064F204D4B5C008033AD /* OIDCCredentialsTest.swift in Sources */,
 				B3AC1A89204825EC00BEB12B /* MockHttpRequest.swift in Sources */,
 				01928B8A201F202D0053EEB0 /* ConfigParserTests.swift in Sources */,
 				B3AC1A8B2049951900BEB12B /* MobileServiceTest.swift in Sources */,
@@ -496,6 +517,7 @@
 				B3AC1A8D2049E11900BEB12B /* UsersTests.swift in Sources */,
 				018FBE6B20123AEE00E763A5 /* AeroGearSdkExampleTests.swift in Sources */,
 				B3AC1A83204815E000BEB12B /* AuthTests.swift in Sources */,
+				EF850651204D6D45008033AD /* CredentialsManagerTest.swift in Sources */,
 				659F2EDBD50348EBB799D1EF /* MetricsServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/example/AeroGearSdkExampleTests/auth/AuthTests.swift
+++ b/example/AeroGearSdkExampleTests/auth/AuthTests.swift
@@ -2,7 +2,7 @@
 // Copyright (c) 2018 AeroGear. All rights reserved.
 //
 
-@testable import AGSCore
+@testable import AGSAuth
 import Foundation
 import XCTest
 

--- a/example/AeroGearSdkExampleTests/auth/credentials/CredentialsManagerTest.swift
+++ b/example/AeroGearSdkExampleTests/auth/credentials/CredentialsManagerTest.swift
@@ -1,0 +1,40 @@
+//
+//  CredentialsManagerTest.swift
+//  AeroGearSdkExampleTests
+
+@testable import AGSAuth
+import XCTest
+
+class CredentialsManagerTest: XCTestCase {
+    let testCredentialManager = CredentialsManager()
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testSaveLoadNotNil() {
+        let testCredential = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: OIDCCredentialsTest.defaultParameters)
+        testCredentialManager.save(credentials: testCredential)
+        let loadedCredentials = testCredentialManager.load()
+        XCTAssertTrue(loadedCredentials?.getAccessToken() == OIDCCredentialsTest.paramAccessTokenVal)
+        XCTAssertTrue(loadedCredentials?.getRefreshToken() == OIDCCredentialsTest.paramRefreshTokenVal)
+        XCTAssertTrue(loadedCredentials?.getIdentitityToken() == OIDCCredentialsTest.paramIdTokenVal)
+    }
+    
+    func testLoadNil() {
+        XCTAssertTrue(testCredentialManager.load() == nil)
+    }
+    
+    func testClear() {
+        let testCredential = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: OIDCCredentialsTest.defaultParameters)
+        testCredentialManager.save(credentials: testCredential)
+        testCredentialManager.clear()
+        XCTAssertTrue(testCredentialManager.load() == nil)
+        
+    }
+    
+}

--- a/example/AeroGearSdkExampleTests/auth/credentials/CredentialsManagerTest.swift
+++ b/example/AeroGearSdkExampleTests/auth/credentials/CredentialsManagerTest.swift
@@ -7,15 +7,15 @@ import XCTest
 
 class CredentialsManagerTest: XCTestCase {
     let testCredentialManager = CredentialsManager()
-    
+
     override func setUp() {
         super.setUp()
     }
-    
+
     override func tearDown() {
         super.tearDown()
     }
-    
+
     func testSaveLoadNotNil() {
         let testCredential = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: OIDCCredentialsTest.defaultParameters)
         testCredentialManager.save(credentials: testCredential)
@@ -24,17 +24,15 @@ class CredentialsManagerTest: XCTestCase {
         XCTAssertTrue(loadedCredentials?.getRefreshToken() == OIDCCredentialsTest.paramRefreshTokenVal)
         XCTAssertTrue(loadedCredentials?.getIdentitityToken() == OIDCCredentialsTest.paramIdTokenVal)
     }
-    
+
     func testLoadNil() {
         XCTAssertTrue(testCredentialManager.load() == nil)
     }
-    
+
     func testClear() {
         let testCredential = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: OIDCCredentialsTest.defaultParameters)
         testCredentialManager.save(credentials: testCredential)
         testCredentialManager.clear()
-        XCTAssertTrue(testCredentialManager.load() == nil)
-        
+        XCTAssertNil(testCredentialManager.load())
     }
-    
 }

--- a/example/AeroGearSdkExampleTests/auth/credentials/CredentialsManagerTest.swift
+++ b/example/AeroGearSdkExampleTests/auth/credentials/CredentialsManagerTest.swift
@@ -20,9 +20,9 @@ class CredentialsManagerTest: XCTestCase {
         let testCredential = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: OIDCCredentialsTest.defaultParameters)
         testCredentialManager.save(credentials: testCredential)
         let loadedCredentials = testCredentialManager.load()
-        XCTAssertEqual(loadedCredentials?.getAccessToken(), OIDCCredentialsTest.paramAccessTokenVal)
-        XCTAssertEqual(loadedCredentials?.getRefreshToken(), OIDCCredentialsTest.paramRefreshTokenVal)
-        XCTAssertEqual(loadedCredentials?.getIdentitityToken(), OIDCCredentialsTest.paramIdTokenVal)
+        XCTAssertEqual(loadedCredentials?.accessToken, OIDCCredentialsTest.paramAccessTokenVal)
+        XCTAssertEqual(loadedCredentials?.refreshToken, OIDCCredentialsTest.paramRefreshTokenVal)
+        XCTAssertEqual(loadedCredentials?.identityToken, OIDCCredentialsTest.paramIdTokenVal)
     }
 
     func testLoadNil() {

--- a/example/AeroGearSdkExampleTests/auth/credentials/CredentialsManagerTest.swift
+++ b/example/AeroGearSdkExampleTests/auth/credentials/CredentialsManagerTest.swift
@@ -20,9 +20,9 @@ class CredentialsManagerTest: XCTestCase {
         let testCredential = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: OIDCCredentialsTest.defaultParameters)
         testCredentialManager.save(credentials: testCredential)
         let loadedCredentials = testCredentialManager.load()
-        XCTAssertTrue(loadedCredentials?.getAccessToken() == OIDCCredentialsTest.paramAccessTokenVal)
-        XCTAssertTrue(loadedCredentials?.getRefreshToken() == OIDCCredentialsTest.paramRefreshTokenVal)
-        XCTAssertTrue(loadedCredentials?.getIdentitityToken() == OIDCCredentialsTest.paramIdTokenVal)
+        XCTAssertEqual(loadedCredentials?.getAccessToken(), OIDCCredentialsTest.paramAccessTokenVal)
+        XCTAssertEqual(loadedCredentials?.getRefreshToken(), OIDCCredentialsTest.paramRefreshTokenVal)
+        XCTAssertEqual(loadedCredentials?.getIdentitityToken(), OIDCCredentialsTest.paramIdTokenVal)
     }
 
     func testLoadNil() {

--- a/example/AeroGearSdkExampleTests/auth/credentials/OIDCCredentialsTest.swift
+++ b/example/AeroGearSdkExampleTests/auth/credentials/OIDCCredentialsTest.swift
@@ -84,11 +84,13 @@ internal class OIDCCredentialsTest: XCTestCase {
         XCTAssertFalse(unauthorizedCredentials.isAuthorized())
     }
 
-    /// Create an OIDCCredentials instance backed by an OIDAuthState with the provided parameters for a token response.
-    /// This allows for mocking most of the important values that are used by OIDCCredentials.
-    ///
-    /// - Parameter parameters: The parameters to mock being provided by a token response e.g. access_token, expires_in.
-    /// - Returns: An OIDCCredentials instance backed by a mocked AuthState using the parameters provided.
+    /**
+     Create an OIDCCredentials instance backed by an OIDAuthState with the provided parameters for a token response.
+     This allows for mocking most of the important values that are used by OIDCCredentials.
+ 
+     - Parameter parameters: The parameters to mock being provided by a token response e.g. access_token, expires_in.
+     - Returns: An OIDCCredentials instance backed by a mocked AuthState using the parameters provided.
+    */
     internal static func buildCredentialsWithParameters(parameters: [String: NSObject & NSCopying]) -> OIDCCredentials {
         let testUrl = URL(string: "https://example.example")!
         let testServiceConfig = OIDServiceConfiguration(authorizationEndpoint: testUrl, tokenEndpoint: testUrl)

--- a/example/AeroGearSdkExampleTests/auth/credentials/OIDCCredentialsTest.swift
+++ b/example/AeroGearSdkExampleTests/auth/credentials/OIDCCredentialsTest.swift
@@ -52,15 +52,15 @@ internal class OIDCCredentialsTest: XCTestCase {
     }
 
     func testGetAccessToken() {
-        XCTAssert(testCredentials?.getAccessToken() == OIDCCredentialsTest.paramAccessTokenVal)
+        XCTAssertEqual(testCredentials?.getAccessToken(), OIDCCredentialsTest.paramAccessTokenVal)
     }
 
     func testGetIdentityToken() {
-        XCTAssert(testCredentials?.getIdentitityToken() == OIDCCredentialsTest.paramIdTokenVal)
+        XCTAssertEqual(testCredentials?.getIdentitityToken(), OIDCCredentialsTest.paramIdTokenVal)
     }
 
     func testGetRefreshToken() {
-        XCTAssert(testCredentials?.getRefreshToken() == OIDCCredentialsTest.paramRefreshTokenVal)
+        XCTAssertEqual(testCredentials?.getRefreshToken(), OIDCCredentialsTest.paramRefreshTokenVal)
     }
 
     func testIsExpired() {

--- a/example/AeroGearSdkExampleTests/auth/credentials/OIDCCredentialsTest.swift
+++ b/example/AeroGearSdkExampleTests/auth/credentials/OIDCCredentialsTest.swift
@@ -1,0 +1,123 @@
+//
+//  OIDCCredentialsTest.swift
+//  AeroGearSdkExampleTests
+//
+
+@testable import AGSAuth
+import AppAuth
+import XCTest
+
+internal class OIDCCredentialsTest: XCTestCase {
+    static let paramCodeKey = "code"
+    static let paramCodeVerifierKey = "code_verifier"
+    static let paramStateKey = "state"
+    static let paramAccessTokenKey = "access_token"
+    static let paramExpiresInKey = "expires_in"
+    static let paramIdTokenKey = "id_token"
+    static let paramTokenTypeKey = "token_type"
+    static let paramScopeKey = "scope"
+    static let paramRefreshTokenKey = "refresh_token"
+    
+    static let paramCodeVal = "testCode"
+    static let paramCodeVerifierVal = "testVerifier"
+    static let paramStateVal = "testState"
+    static let paramAccessTokenVal = "testAccessToken"
+    static let paramExpiresInVal = 60
+    static let paramIdTokenVal = "testIdentityToken"
+    static let paramTokenTypeVal = "testTokenType"
+    static let paramScopeVal = "testScope"
+    static let paramRefreshTokenVal = "testRefreshToken"
+    
+    static let defaultParameters = [
+        paramCodeKey: paramCodeVal as NSString,
+        paramCodeVerifierKey: paramCodeVerifierVal as NSString,
+        paramStateKey: paramStateVal as NSString,
+        paramAccessTokenKey: paramAccessTokenVal as NSString,
+        paramExpiresInKey: paramExpiresInVal as NSNumber,
+        paramIdTokenKey: paramIdTokenVal as NSString,
+        paramTokenTypeKey: paramTokenTypeVal as NSString,
+        paramScopeKey: paramScopeVal as NSString,
+        paramRefreshTokenKey: paramRefreshTokenVal as NSString
+    ] as [String : NSObject & NSCopying]
+    
+    var testCredentials : OIDCCredentials?
+    
+    override func setUp() {
+        super.setUp()
+        testCredentials = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: OIDCCredentialsTest.defaultParameters)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testGetAccessToken() {
+        XCTAssert(testCredentials?.getAccessToken() == OIDCCredentialsTest.paramAccessTokenVal)
+    }
+    
+    func testGetIdentityToken() {
+        XCTAssert(testCredentials?.getIdentitityToken() == OIDCCredentialsTest.paramIdTokenVal)
+    }
+
+    func testGetRefreshToken() {
+        XCTAssert(testCredentials?.getRefreshToken() == OIDCCredentialsTest.paramRefreshTokenVal)
+    }
+
+    func testIsExpired() {
+        XCTAssertFalse((testCredentials?.isExpired())!)
+    }
+    
+    func testIsExpiredWithExpiredToken() {
+        var expiredParameters = OIDCCredentialsTest.defaultParameters
+        expiredParameters[OIDCCredentialsTest.paramExpiresInKey] = 0 as NSNumber
+        
+        let expiredCredentials = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: expiredParameters)
+        XCTAssertTrue(expiredCredentials.isExpired())
+    }
+    
+    func testIsAuthorized() {
+        XCTAssertTrue((testCredentials?.isAuthorized())!)
+    }
+    
+    func testIsAuthorizedWithUnauthorizedState() {
+        let unauthorizedCredentials = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: [:])
+        XCTAssertFalse(unauthorizedCredentials.isAuthorized())
+    }
+    
+    /// Create an OIDCCredentials instance backed by an OIDAuthState with the provided parameters for a token response.
+    /// This allows for mocking most of the important values that are used by OIDCCredentials.
+    ///
+    /// - Parameter parameters: The parameters to mock being provided by a token response e.g. access_token, expires_in.
+    /// - Returns: An OIDCCredentials instance backed by a mocked AuthState using the parameters provided.
+    internal static func buildCredentialsWithParameters(parameters: [String : NSObject & NSCopying]) -> OIDCCredentials {
+        let testUrl = URL(string: "https://example.example")!
+        let testServiceConfig = OIDServiceConfiguration(authorizationEndpoint: testUrl, tokenEndpoint: testUrl)
+        let testRequest = OIDAuthorizationRequest(configuration: testServiceConfig,
+                                                  clientId: "exampleClientId",
+                                                  clientSecret: "exampleClientSecret",
+                                                  scope: "exampleClientScope",
+                                                  redirectURL: testUrl,
+                                                  responseType: "code",
+                                                  state: "testState",
+                                                  codeVerifier: "testVerifier",
+                                                  codeChallenge: OIDAuthorizationRequest.codeChallengeS256(forVerifier: "testVerifier"),
+                                                  codeChallengeMethod: OIDOAuthorizationRequestCodeChallengeMethodS256,
+                                                  additionalParameters: [:])
+        let testResponse = OIDAuthorizationResponse(request: testRequest, parameters: [:])
+        
+        let testTokenRequest = OIDTokenRequest(configuration: testServiceConfig,
+                                               grantType: OIDGrantTypeAuthorizationCode,
+                                               authorizationCode: "Code",
+                                               redirectURL: testUrl,
+                                               clientID: "testClientId",
+                                               clientSecret: "testSecret",
+                                               scope: "testScope",
+                                               refreshToken: "testRefreshToken",
+                                               codeVerifier: "testVerifier",
+                                               additionalParameters: nil)
+        let testTokenResponse = OIDTokenResponse(request: testTokenRequest, parameters: parameters)
+        
+        let authState = OIDAuthState(authorizationResponse: testResponse, tokenResponse: testTokenResponse)
+        return OIDCCredentials(state: authState)
+    }
+}

--- a/example/AeroGearSdkExampleTests/auth/credentials/OIDCCredentialsTest.swift
+++ b/example/AeroGearSdkExampleTests/auth/credentials/OIDCCredentialsTest.swift
@@ -52,19 +52,19 @@ internal class OIDCCredentialsTest: XCTestCase {
     }
 
     func testGetAccessToken() {
-        XCTAssertEqual(testCredentials?.getAccessToken(), OIDCCredentialsTest.paramAccessTokenVal)
+        XCTAssertEqual(testCredentials?.accessToken, OIDCCredentialsTest.paramAccessTokenVal)
     }
 
     func testGetIdentityToken() {
-        XCTAssertEqual(testCredentials?.getIdentitityToken(), OIDCCredentialsTest.paramIdTokenVal)
+        XCTAssertEqual(testCredentials?.identityToken, OIDCCredentialsTest.paramIdTokenVal)
     }
 
     func testGetRefreshToken() {
-        XCTAssertEqual(testCredentials?.getRefreshToken(), OIDCCredentialsTest.paramRefreshTokenVal)
+        XCTAssertEqual(testCredentials?.refreshToken, OIDCCredentialsTest.paramRefreshTokenVal)
     }
 
     func testIsExpired() {
-        XCTAssertFalse((testCredentials?.isExpired())!)
+        XCTAssertFalse((testCredentials?.isExpired)!)
     }
 
     func testIsExpiredWithExpiredToken() {
@@ -72,16 +72,16 @@ internal class OIDCCredentialsTest: XCTestCase {
         expiredParameters[OIDCCredentialsTest.paramExpiresInKey] = 0 as NSNumber
 
         let expiredCredentials = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: expiredParameters)
-        XCTAssertTrue(expiredCredentials.isExpired())
+        XCTAssertTrue(expiredCredentials.isExpired)
     }
 
     func testIsAuthorized() {
-        XCTAssertTrue((testCredentials?.isAuthorized())!)
+        XCTAssertTrue((testCredentials?.isAuthorized)!)
     }
 
     func testIsAuthorizedWithUnauthorizedState() {
         let unauthorizedCredentials = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: [:])
-        XCTAssertFalse(unauthorizedCredentials.isAuthorized())
+        XCTAssertFalse(unauthorizedCredentials.isAuthorized)
     }
 
     /**

--- a/example/AeroGearSdkExampleTests/auth/credentials/OIDCCredentialsTest.swift
+++ b/example/AeroGearSdkExampleTests/auth/credentials/OIDCCredentialsTest.swift
@@ -17,7 +17,7 @@ internal class OIDCCredentialsTest: XCTestCase {
     static let paramTokenTypeKey = "token_type"
     static let paramScopeKey = "scope"
     static let paramRefreshTokenKey = "refresh_token"
-    
+
     static let paramCodeVal = "testCode"
     static let paramCodeVerifierVal = "testVerifier"
     static let paramStateVal = "testState"
@@ -27,7 +27,7 @@ internal class OIDCCredentialsTest: XCTestCase {
     static let paramTokenTypeVal = "testTokenType"
     static let paramScopeVal = "testScope"
     static let paramRefreshTokenVal = "testRefreshToken"
-    
+
     static let defaultParameters = [
         paramCodeKey: paramCodeVal as NSString,
         paramCodeVerifierKey: paramCodeVerifierVal as NSString,
@@ -37,24 +37,24 @@ internal class OIDCCredentialsTest: XCTestCase {
         paramIdTokenKey: paramIdTokenVal as NSString,
         paramTokenTypeKey: paramTokenTypeVal as NSString,
         paramScopeKey: paramScopeVal as NSString,
-        paramRefreshTokenKey: paramRefreshTokenVal as NSString
-    ] as [String : NSObject & NSCopying]
-    
-    var testCredentials : OIDCCredentials?
-    
+        paramRefreshTokenKey: paramRefreshTokenVal as NSString,
+    ] as [String: NSObject & NSCopying]
+
+    var testCredentials: OIDCCredentials?
+
     override func setUp() {
         super.setUp()
         testCredentials = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: OIDCCredentialsTest.defaultParameters)
     }
-    
+
     override func tearDown() {
         super.tearDown()
     }
-    
+
     func testGetAccessToken() {
         XCTAssert(testCredentials?.getAccessToken() == OIDCCredentialsTest.paramAccessTokenVal)
     }
-    
+
     func testGetIdentityToken() {
         XCTAssert(testCredentials?.getIdentitityToken() == OIDCCredentialsTest.paramIdTokenVal)
     }
@@ -66,30 +66,30 @@ internal class OIDCCredentialsTest: XCTestCase {
     func testIsExpired() {
         XCTAssertFalse((testCredentials?.isExpired())!)
     }
-    
+
     func testIsExpiredWithExpiredToken() {
         var expiredParameters = OIDCCredentialsTest.defaultParameters
         expiredParameters[OIDCCredentialsTest.paramExpiresInKey] = 0 as NSNumber
-        
+
         let expiredCredentials = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: expiredParameters)
         XCTAssertTrue(expiredCredentials.isExpired())
     }
-    
+
     func testIsAuthorized() {
         XCTAssertTrue((testCredentials?.isAuthorized())!)
     }
-    
+
     func testIsAuthorizedWithUnauthorizedState() {
         let unauthorizedCredentials = OIDCCredentialsTest.buildCredentialsWithParameters(parameters: [:])
         XCTAssertFalse(unauthorizedCredentials.isAuthorized())
     }
-    
+
     /// Create an OIDCCredentials instance backed by an OIDAuthState with the provided parameters for a token response.
     /// This allows for mocking most of the important values that are used by OIDCCredentials.
     ///
     /// - Parameter parameters: The parameters to mock being provided by a token response e.g. access_token, expires_in.
     /// - Returns: An OIDCCredentials instance backed by a mocked AuthState using the parameters provided.
-    internal static func buildCredentialsWithParameters(parameters: [String : NSObject & NSCopying]) -> OIDCCredentials {
+    internal static func buildCredentialsWithParameters(parameters: [String: NSObject & NSCopying]) -> OIDCCredentials {
         let testUrl = URL(string: "https://example.example")!
         let testServiceConfig = OIDServiceConfiguration(authorizationEndpoint: testUrl, tokenEndpoint: testUrl)
         let testRequest = OIDAuthorizationRequest(configuration: testServiceConfig,
@@ -104,7 +104,7 @@ internal class OIDCCredentialsTest: XCTestCase {
                                                   codeChallengeMethod: OIDOAuthorizationRequestCodeChallengeMethodS256,
                                                   additionalParameters: [:])
         let testResponse = OIDAuthorizationResponse(request: testRequest, parameters: [:])
-        
+
         let testTokenRequest = OIDTokenRequest(configuration: testServiceConfig,
                                                grantType: OIDGrantTypeAuthorizationCode,
                                                authorizationCode: "Code",
@@ -116,7 +116,7 @@ internal class OIDCCredentialsTest: XCTestCase {
                                                codeVerifier: "testVerifier",
                                                additionalParameters: nil)
         let testTokenResponse = OIDTokenResponse(request: testTokenRequest, parameters: parameters)
-        
+
         let authState = OIDAuthState(authorizationResponse: testResponse, tokenResponse: testTokenResponse)
         return OIDCCredentials(state: authState)
     }

--- a/modules/auth/agsauth.podspec
+++ b/modules/auth/agsauth.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   ## Default core dependency
   s.dependency 'AGSCore'
   ## Add other dependencies if needed
-  s.dependency 'AppAuth'
-  s.dependency 'SwiftKeychainWrapper'
+  s.dependency 'AppAuth', '~> 0.92'
+  s.dependency 'SwiftKeychainWrapper', '~> 3.0.1'
   s.requires_arc = true
 end

--- a/modules/auth/agsauth.podspec
+++ b/modules/auth/agsauth.podspec
@@ -18,5 +18,6 @@ Pod::Spec.new do |s|
   s.dependency 'AGSCore'
   ## Add other dependencies if needed
   s.dependency 'AppAuth'
+  s.dependency 'SwiftKeychainWrapper'
   s.requires_arc = true
 end

--- a/modules/auth/credentials/CredentialsManager.swift
+++ b/modules/auth/credentials/CredentialsManager.swift
@@ -2,7 +2,6 @@
 //  CredentialsManager.swift
 //  AGSAuth
 
-import AppAuth
 import Foundation
 import Security
 import SwiftKeychainWrapper
@@ -11,14 +10,14 @@ import SwiftKeychainWrapper
 public protocol CredentialManagerProtocol {
     /**
      Get the stored credentials.
-     
+
      - Returns: The stored credentials.
      */
     func load() -> OIDCCredentials?
-    
+
     /**
      Overwrite the currently stored credentials.
-     
+
      - Parameter credentials: The credentials to store.
      */
     func save(credentials: OIDCCredentials)
@@ -30,19 +29,18 @@ public protocol CredentialManagerProtocol {
 /** Persist/load the OIDCCredentials */
 public class CredentialsManager: CredentialManagerProtocol {
     let authStateKey = "org.aerogear.AuthState"
-    var authState: OIDAuthState?
 
     public init() {}
-    
+
     public func load() -> OIDCCredentials? {
         if let state = KeychainWrapper.standard.object(forKey: authStateKey) {
-            return OIDCCredentials(state: state as! OIDAuthState)
+            return state as? OIDCCredentials
         }
         return nil
     }
 
     public func save(credentials: OIDCCredentials) {
-        KeychainWrapper.standard.set(credentials.authState, forKey: authStateKey)
+        KeychainWrapper.standard.set(credentials, forKey: authStateKey)
     }
 
     public func clear() {

--- a/modules/auth/credentials/CredentialsManager.swift
+++ b/modules/auth/credentials/CredentialsManager.swift
@@ -3,23 +3,42 @@
 //  AGSAuth
 
 import Foundation
+import AppAuth
+import Security
+import SwiftKeychainWrapper
 
-protocol CredentialManagerProtocol {
+public protocol CredentialManagerProtocol {
     func load() -> OIDCCredentials?
     func save(credentials: OIDCCredentials)
     func clear()
 }
 
 /** Persist/load the OIDCCredentials */
-class CredentialsManager: CredentialManagerProtocol {
-    func load() -> OIDCCredentials? {
-        return nil
-    }
+public class CredentialsManager : CredentialManagerProtocol {
+    let AUTH_STATE_KEY = "authState"
+    var authState: OIDAuthState?
+    
+    public init() {}
 
-    func save(credentials _: OIDCCredentials) {
+    /// Get the stored credentials.
+    ///
+    /// - Returns: The stored credentials.
+    public func load() -> OIDCCredentials? {
+        guard let state = KeychainWrapper.standard.object(forKey: AUTH_STATE_KEY) else {
+            return nil
+        }
+        return OIDCCredentials(state: state as! OIDAuthState)
     }
-
-    /** Remove local credentials */
-    func clear() {
+    
+    /// Overwrite the currently stored credentials.
+    ///
+    /// - Parameter credentials: The credentials to store.
+    public func save(credentials: OIDCCredentials) {
+        KeychainWrapper.standard.set(credentials.authState, forKey: AUTH_STATE_KEY)
+    }
+    
+    /// Remove the currently stored credentials.
+    public func clear() {
+        KeychainWrapper.standard.removeObject(forKey: AUTH_STATE_KEY)
     }
 }

--- a/modules/auth/credentials/CredentialsManager.swift
+++ b/modules/auth/credentials/CredentialsManager.swift
@@ -2,8 +2,8 @@
 //  CredentialsManager.swift
 //  AGSAuth
 
-import Foundation
 import AppAuth
+import Foundation
 import Security
 import SwiftKeychainWrapper
 
@@ -14,31 +14,31 @@ public protocol CredentialManagerProtocol {
 }
 
 /** Persist/load the OIDCCredentials */
-public class CredentialsManager : CredentialManagerProtocol {
-    let AUTH_STATE_KEY = "authState"
+public class CredentialsManager: CredentialManagerProtocol {
+    let authStateKey = "authState"
     var authState: OIDAuthState?
-    
+
     public init() {}
 
     /// Get the stored credentials.
     ///
     /// - Returns: The stored credentials.
     public func load() -> OIDCCredentials? {
-        guard let state = KeychainWrapper.standard.object(forKey: AUTH_STATE_KEY) else {
-            return nil
+        if let state = KeychainWrapper.standard.object(forKey: authStateKey) {
+            return OIDCCredentials(state: state as! OIDAuthState)
         }
-        return OIDCCredentials(state: state as! OIDAuthState)
+        return nil
     }
-    
+
     /// Overwrite the currently stored credentials.
     ///
     /// - Parameter credentials: The credentials to store.
     public func save(credentials: OIDCCredentials) {
-        KeychainWrapper.standard.set(credentials.authState, forKey: AUTH_STATE_KEY)
+        KeychainWrapper.standard.set(credentials.authState, forKey: authStateKey)
     }
-    
+
     /// Remove the currently stored credentials.
     public func clear() {
-        KeychainWrapper.standard.removeObject(forKey: AUTH_STATE_KEY)
+        KeychainWrapper.standard.removeObject(forKey: authStateKey)
     }
 }

--- a/modules/auth/credentials/CredentialsManager.swift
+++ b/modules/auth/credentials/CredentialsManager.swift
@@ -15,7 +15,7 @@ public protocol CredentialManagerProtocol {
 
 /** Persist/load the OIDCCredentials */
 public class CredentialsManager: CredentialManagerProtocol {
-    let authStateKey = "authState"
+    let authStateKey = "org.aerogear.AuthState"
     var authState: OIDAuthState?
 
     public init() {}

--- a/modules/auth/credentials/CredentialsManager.swift
+++ b/modules/auth/credentials/CredentialsManager.swift
@@ -7,9 +7,23 @@ import Foundation
 import Security
 import SwiftKeychainWrapper
 
+/** Persist/load credentials */
 public protocol CredentialManagerProtocol {
+    /**
+     Get the stored credentials.
+     
+     - Returns: The stored credentials.
+     */
     func load() -> OIDCCredentials?
+    
+    /**
+     Overwrite the currently stored credentials.
+     
+     - Parameter credentials: The credentials to store.
+     */
     func save(credentials: OIDCCredentials)
+
+    /** Remove the currently stored credentials. */
     func clear()
 }
 
@@ -19,11 +33,7 @@ public class CredentialsManager: CredentialManagerProtocol {
     var authState: OIDAuthState?
 
     public init() {}
-    /**
-     Get the stored credentials.
- 
-     - Returns: The stored credentials.
-    */
+    
     public func load() -> OIDCCredentials? {
         if let state = KeychainWrapper.standard.object(forKey: authStateKey) {
             return OIDCCredentials(state: state as! OIDAuthState)
@@ -31,16 +41,10 @@ public class CredentialsManager: CredentialManagerProtocol {
         return nil
     }
 
-    /**
-     Overwrite the currently stored credentials.
- 
-     - Parameter credentials: The credentials to store.
-    */
     public func save(credentials: OIDCCredentials) {
         KeychainWrapper.standard.set(credentials.authState, forKey: authStateKey)
     }
 
-    /** Remove the currently stored credentials. */
     public func clear() {
         KeychainWrapper.standard.removeObject(forKey: authStateKey)
     }

--- a/modules/auth/credentials/CredentialsManager.swift
+++ b/modules/auth/credentials/CredentialsManager.swift
@@ -19,10 +19,11 @@ public class CredentialsManager: CredentialManagerProtocol {
     var authState: OIDAuthState?
 
     public init() {}
-
-    /// Get the stored credentials.
-    ///
-    /// - Returns: The stored credentials.
+    /**
+     Get the stored credentials.
+ 
+     - Returns: The stored credentials.
+    */
     public func load() -> OIDCCredentials? {
         if let state = KeychainWrapper.standard.object(forKey: authStateKey) {
             return OIDCCredentials(state: state as! OIDAuthState)
@@ -30,14 +31,16 @@ public class CredentialsManager: CredentialManagerProtocol {
         return nil
     }
 
-    /// Overwrite the currently stored credentials.
-    ///
-    /// - Parameter credentials: The credentials to store.
+    /**
+     Overwrite the currently stored credentials.
+ 
+     - Parameter credentials: The credentials to store.
+    */
     public func save(credentials: OIDCCredentials) {
         KeychainWrapper.standard.set(credentials.authState, forKey: authStateKey)
     }
 
-    /// Remove the currently stored credentials.
+    /** Remove the currently stored credentials. */
     public func clear() {
         KeychainWrapper.standard.removeObject(forKey: authStateKey)
     }

--- a/modules/auth/credentials/OIDCCredentials.swift
+++ b/modules/auth/credentials/OIDCCredentials.swift
@@ -14,37 +14,47 @@ public class OIDCCredentials {
         authState = state
     }
 
-    /// Get the access token for the credential.
-    ///
-    /// - Returns: An access token.
+    /**
+     Get the access token for the credential.
+ 
+     - Returns: An access token.
+    */
     public func getAccessToken() -> String? {
         return authState.lastTokenResponse?.accessToken
     }
 
-    /// Get the identity token for the credential.
-    ///
-    /// - Returns: An identity token.
+    /**
+     Get the identity token for the credential.
+
+     - Returns: An identity token.
+    */
     public func getIdentitityToken() -> String? {
         return authState.lastTokenResponse?.idToken
     }
 
-    /// Get the refresh token for the credential.
-    ///
-    /// - Returns: A refresh token.
+    /**
+     Get the refresh token for the credential.
+
+     - Returns: A refresh token.
+    */
     public func getRefreshToken() -> String? {
         return authState.lastTokenResponse?.refreshToken
     }
 
-    /// Check whether the token is expired. This is based on the expires_in value of the token response.
-    ///
-    /// - Returns: true if the token is expired.
+    /**
+     Check whether the token is expired. This is based on the expires_in value of the token response.
+
+     - Returns: true if the token is expired.
+    */
     public func isExpired() -> Bool {
         return (authState.lastTokenResponse?.accessTokenExpirationDate)! < Date()
     }
 
-    /// If the credential is in an authorized state.
-    ///
-    /// - Returns: true if the credential is authorized.
+    /**
+     If the credential is in an authorized state.
+ 
+     - Returns: true if the credential is authorized.
+    */
     public func isAuthorized() -> Bool {
         return authState.isAuthorized
     }

--- a/modules/auth/credentials/OIDCCredentials.swift
+++ b/modules/auth/credentials/OIDCCredentials.swift
@@ -5,57 +5,39 @@
 import AppAuth
 import Foundation
 
-/// A class to represent the OpenID Connect state for an entity.
-/// This is backed by a standard OIDC token.
+/**
+ A class to represent the OpenID Connect state for an entity.
+ This is backed by a standard OIDC token.
+*/
 public class OIDCCredentials {
     let authState: OIDAuthState
-
-    public init(state: OIDAuthState) {
-        authState = state
-    }
-
-    /**
-     Get the access token for the credential.
- 
-     - Returns: An access token.
-    */
-    public func getAccessToken() -> String? {
+    
+    /** Access token of the credential. Will be nil if not authorized. */
+    var accessToken: String? {
         return authState.lastTokenResponse?.accessToken
     }
-
-    /**
-     Get the identity token for the credential.
-
-     - Returns: An identity token.
-    */
-    public func getIdentitityToken() -> String? {
+    
+    /** Identity token of the credential. Will be nil if not authorized. */
+    var identityToken: String? {
         return authState.lastTokenResponse?.idToken
     }
-
-    /**
-     Get the refresh token for the credential.
-
-     - Returns: A refresh token.
-    */
-    public func getRefreshToken() -> String? {
+    
+    /** Refresh token of the credential. Will be nil if not authorized. */
+    var refreshToken: String? {
         return authState.lastTokenResponse?.refreshToken
     }
-
-    /**
-     Check whether the token is expired. This is based on the expires_in value of the token response.
-
-     - Returns: true if the token is expired.
-    */
-    public func isExpired() -> Bool {
+    
+    /** Whether the credential is currently authorized. */
+    var isAuthorized: Bool {
+        return authState.isAuthorized
+    }
+    
+    /** Whether the token backing the credential is expired. Will be nil if not authorized. */
+    var isExpired: Bool {
         return (authState.lastTokenResponse?.accessTokenExpirationDate)! < Date()
     }
-
-    /**
-     If the credential is in an authorized state.
- 
-     - Returns: true if the credential is authorized.
-    */
-    public func isAuthorized() -> Bool {
-        return authState.isAuthorized
+    
+    public init(state: OIDAuthState) {
+        authState = state
     }
 }

--- a/modules/auth/credentials/OIDCCredentials.swift
+++ b/modules/auth/credentials/OIDCCredentials.swift
@@ -5,14 +5,47 @@
 import AppAuth
 import Foundation
 
-class OIDCCredentials {
+/// A class to represent the OpenID Connect state for an entity.
+/// This is backed by a standard OIDC token.
+public class OIDCCredentials {
     let authState: OIDAuthState
 
-    init(state: OIDAuthState) {
-        authState = state
+    public init(state: OIDAuthState) {
+        self.authState = state
     }
 
-    func getAccessToken() -> String? {
-        return nil
+    /// Get the access token for the credential.
+    ///
+    /// - Returns: An access token.
+    public func getAccessToken() -> String? {
+        return authState.lastTokenResponse?.accessToken
+    }
+    
+    /// Get the identity token for the credential.
+    ///
+    /// - Returns: An identity token.
+    public func getIdentitityToken() -> String? {
+        return authState.lastTokenResponse?.idToken
+    }
+    
+    /// Get the refresh token for the credential.
+    ///
+    /// - Returns: A refresh token.
+    public func getRefreshToken() -> String? {
+        return authState.lastTokenResponse?.refreshToken
+    }
+    
+    /// Check whether the token is expired. This is based on the expires_in value of the token response.
+    ///
+    /// - Returns: true if the token is expired.
+    public func isExpired() -> Bool {
+        return (authState.lastTokenResponse?.accessTokenExpirationDate)! < Date()
+    }
+    
+    /// If the credential is in an authorized state.
+    ///
+    /// - Returns: true if the credential is authorized.
+    public func isAuthorized() -> Bool {
+        return authState.isAuthorized
     }
 }

--- a/modules/auth/credentials/OIDCCredentials.swift
+++ b/modules/auth/credentials/OIDCCredentials.swift
@@ -8,36 +8,45 @@ import Foundation
 /**
  A class to represent the OpenID Connect state for an entity.
  This is backed by a standard OIDC token.
-*/
-public class OIDCCredentials {
+ */
+public class OIDCCredentials: NSObject, NSCoding {
+    static let authStateEncodingKey = "authState"
     let authState: OIDAuthState
-    
+
     /** Access token of the credential. Will be nil if not authorized. */
     var accessToken: String? {
         return authState.lastTokenResponse?.accessToken
     }
-    
+
     /** Identity token of the credential. Will be nil if not authorized. */
     var identityToken: String? {
         return authState.lastTokenResponse?.idToken
     }
-    
+
     /** Refresh token of the credential. Will be nil if not authorized. */
     var refreshToken: String? {
         return authState.lastTokenResponse?.refreshToken
     }
-    
+
     /** Whether the credential is currently authorized. */
     var isAuthorized: Bool {
         return authState.isAuthorized
     }
-    
+
     /** Whether the token backing the credential is expired. Will be nil if not authorized. */
     var isExpired: Bool {
         return (authState.lastTokenResponse?.accessTokenExpirationDate)! < Date()
     }
-    
+
     public init(state: OIDAuthState) {
         authState = state
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        authState = aDecoder.decodeObject(forKey: OIDCCredentials.authStateEncodingKey) as! OIDAuthState
+    }
+
+    public func encode(with aCoder: NSCoder) {
+        aCoder.encode(authState, forKey: OIDCCredentials.authStateEncodingKey)
     }
 }

--- a/modules/auth/credentials/OIDCCredentials.swift
+++ b/modules/auth/credentials/OIDCCredentials.swift
@@ -11,7 +11,7 @@ public class OIDCCredentials {
     let authState: OIDAuthState
 
     public init(state: OIDAuthState) {
-        self.authState = state
+        authState = state
     }
 
     /// Get the access token for the credential.
@@ -20,28 +20,28 @@ public class OIDCCredentials {
     public func getAccessToken() -> String? {
         return authState.lastTokenResponse?.accessToken
     }
-    
+
     /// Get the identity token for the credential.
     ///
     /// - Returns: An identity token.
     public func getIdentitityToken() -> String? {
         return authState.lastTokenResponse?.idToken
     }
-    
+
     /// Get the refresh token for the credential.
     ///
     /// - Returns: A refresh token.
     public func getRefreshToken() -> String? {
         return authState.lastTokenResponse?.refreshToken
     }
-    
+
     /// Check whether the token is expired. This is based on the expires_in value of the token response.
     ///
     /// - Returns: true if the token is expired.
     public func isExpired() -> Bool {
         return (authState.lastTokenResponse?.accessTokenExpirationDate)! < Date()
     }
-    
+
     /// If the credential is in an authorized state.
     ///
     /// - Returns: true if the credential is authorized.


### PR DESCRIPTION
### Motivation

We need a way to store and manage credentials.

JIRA: [AEROGEAR-2092](https://issues.jboss.org/browse/AEROGEAR-2092)

### Description

Create an OIDCCredentials object which is backed by an OIDAuthState.

Create a CredentialManager which takes the OIDAuthState from the OIDCCredentials and stores it using a Keychain storage library.

### Progress

- [x] OIDCCredentials
- [x] CredentialManager
- [x] OIDCCredentialsTest
- [x] CredentialManagerTest
- [x] Make OIDCCredentials NSCoding compliant (so the CredentialManager doesn't need to know about authState)