### PR TITLE
[WIP] Allow empty JSON responses in HTTP module

### DIFF
--- a/modules/core/http/AgsHttpRequest.swift
+++ b/modules/core/http/AgsHttpRequest.swift
@@ -20,22 +20,26 @@ public class AgsHttpRequest: AgsHttpRequestProtocol {
     public func get(_ url: String, params: [String: AnyObject]? = [:], headers: [String: String]? = [:],
                     _ handler: @escaping (Any?, Error?) -> Void) {
         Alamofire.request(url, parameters: params, headers: headers).responseJSON { (responseObject) -> Void in
-            if responseObject.result.isSuccess {
+            if self.isHTTPResponseSuccess(responseObject)  {
                 handler(responseObject.result.value, nil)
+                return
             }
             if responseObject.result.isFailure {
                 handler(nil, responseObject.result.error)
+                return
             }
         }
     }
 
     public func post(_ url: String, body: [String: Any]? = [:], headers: [String: String]? = [:], _ handler: @escaping (Any?, Error?) -> Void) {
         Alamofire.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: headers).responseJSON { (responseObject) -> Void in
-            if responseObject.result.isSuccess {
+            if self.isHTTPResponseSuccess(responseObject) {
                 handler(responseObject.result.value, nil)
+                return
             }
             if responseObject.result.isFailure {
                 handler(nil, responseObject.result.error)
+                return
             }
         }
     }
@@ -43,11 +47,13 @@ public class AgsHttpRequest: AgsHttpRequestProtocol {
     public func put(_ url: String, body: [String: Any]? = [:], headers: [String: String]? = [:], _ handler: @escaping (Any?, Error?) -> Void) {
         Alamofire.request(url, method: .put, parameters: body, encoding: JSONEncoding.default, headers: headers).responseJSON { (responseObject) -> Void in
 
-            if responseObject.result.isSuccess {
+            if self.isHTTPResponseSuccess(responseObject) {
                 handler(responseObject.result.value, nil)
+                return
             }
             if responseObject.result.isFailure {
                 handler(nil, responseObject.result.error)
+                return
             }
         }
     }
@@ -55,13 +61,22 @@ public class AgsHttpRequest: AgsHttpRequestProtocol {
     public func delete(_ url: String, headers: [String: String]? = [:], _ handler: @escaping (Any?, Error?) -> Void) {
         Alamofire.request(url, method: .delete, encoding: JSONEncoding.default, headers: headers).responseJSON { (responseObject) -> Void in
 
-            if responseObject.result.isSuccess {
+            if self.isHTTPResponseSuccess(responseObject) {
                 handler(responseObject.result.value, nil)
+                return
             }
             if responseObject.result.isFailure {
                 handler(nil, responseObject.result.error)
+                return
             }
         }
+    }
+    
+    /**
+     Check whether a response is successful.
+    */
+    private func isHTTPResponseSuccess(_ responseObject: DataResponse<Any>) -> Bool {
+        return responseObject.result.isSuccess || (200..<300).contains(responseObject.response?.statusCode ?? 0)
     }
 }
 


### PR DESCRIPTION
### Motivation

Currently HTTP responses will result in an error if a responses body
is empty, even though the status code is 2xx.

### Description

This allows the HTTP check to succeed regardless of whether there is
a body to the response. This was discovered as part of the Keycloak
logout request.

### Progress

- [x] Add isHTTPResponseSuccess function