### PR TITLE
Allow empty json responses

### DIFF
--- a/example/AeroGearSdkExample/home/HomeViewController.swift
+++ b/example/AeroGearSdkExample/home/HomeViewController.swift
@@ -18,7 +18,7 @@ class HomeViewController: UIViewController, UIPickerViewDataSource, UIPickerView
 
     var currentConfig: MobileService?
 
-    var pickerDataSource = ["fh-sync-server", "prometheus", "keycloak", "metrics"]
+    var pickerDataSource = ["keycloak", "metrics"]
 
     @IBAction func buttonClick(sender _: UIButton) {
         if let uri = currentConfig?.url {

--- a/example/AeroGearSdkExample/mobile-services.json
+++ b/example/AeroGearSdkExample/mobile-services.json
@@ -5,14 +5,6 @@
   "clientId": "example_client_id",
   "services": [
     {
-      "id": "fh-sync-server",
-      "name": "fh-sync-server",
-      "type": "fh-sync-server",
-      "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
-      "config": {
-      }
-    },
-    {
       "id": "keycloak",
       "name": "keycloak",
       "type": "keycloak",
@@ -27,17 +19,10 @@
       }
     },
     {
-      "id": "prometheus",
-      "name": "prometheus",
-      "type": "prometheus",
-      "url": "https://www.mocky.io/v2/5a6b59fb31000088191b8ac6",
-      "config": {}
-    },
-    {
       "id": "metrics",
       "name": "metrics",
       "type": "metrics",
-      "url": "http://www.mocky.io/v2/5a79c6572e000028009a5c4f",
+      "url": "https://www.mocky.io/v2/5aa696133100001335e716e0",
       "config": {}
    }
   ]

--- a/example/AeroGearSdkExampleTests/auth/config/KeycloakConfigTests.swift
+++ b/example/AeroGearSdkExampleTests/auth/config/KeycloakConfigTests.swift
@@ -55,7 +55,7 @@ class KeycloakConfigTests: XCTestCase {
     
     func testLogoutURL() {
         let actual = keycloakConfig?.buildLogoutURL(idToken: "testToken")
-        let expected = "https://keycloak-myproject.192.168.64.74.nip.io/auth/realms/myproject/protocol/openid-connect/logout?id_token_hint=testToken&redirect_uri=com.aerogear.mobile.test://calback"
+        let expected = "https://keycloak-myproject.192.168.64.74.nip.io/auth/realms/myproject/protocol/openid-connect/logout?id_token_hint=testToken"
         
         XCTAssertEqual(expected, actual)
     }

--- a/modules/auth/config/KeycloakConfig.swift
+++ b/modules/auth/config/KeycloakConfig.swift
@@ -16,7 +16,7 @@ class KeycloakConfig {
     private let redirectFragment = "redirect_uri"
 
     private let baseUrlTemplate = "%@/realms/%@/protocol/openid-connect"
-    private let logoutUrlTemplate = "%@/logout?%@=%@&%@=%@"
+    private let logoutUrlTemplate = "%@/logout?%@=%@"
 
     private let authConfig: AuthenticationConfig
 
@@ -77,7 +77,7 @@ class KeycloakConfig {
      - returns: logout URL
      */
     func buildLogoutURL(idToken: String) -> String {
-        return String(format: logoutUrlTemplate, baseUrl, tokenHintFragment, idToken, redirectFragment, authConfig.redirectURL.absoluteString)
+        return String(format: logoutUrlTemplate, baseUrl, tokenHintFragment, idToken)
     }
 
     /**

--- a/modules/core/http/AgsHttpRequest.swift
+++ b/modules/core/http/AgsHttpRequest.swift
@@ -20,22 +20,26 @@ public class AgsHttpRequest: AgsHttpRequestProtocol {
     public func get(_ url: String, params: [String: AnyObject]? = [:], headers: [String: String]? = [:],
                     _ handler: @escaping (Any?, Error?) -> Void) {
         Alamofire.request(url, parameters: params, headers: headers).responseJSON { (responseObject) -> Void in
-            if responseObject.result.isSuccess {
+            if self.isHTTPResponseSuccess(responseObject)  {
                 handler(responseObject.result.value, nil)
+                return
             }
             if responseObject.result.isFailure {
                 handler(nil, responseObject.result.error)
+                return
             }
         }
     }
 
     public func post(_ url: String, body: [String: Any]? = [:], headers: [String: String]? = [:], _ handler: @escaping (Any?, Error?) -> Void) {
         Alamofire.request(url, method: .post, parameters: body, encoding: JSONEncoding.default, headers: headers).responseJSON { (responseObject) -> Void in
-            if responseObject.result.isSuccess {
+            if self.isHTTPResponseSuccess(responseObject) {
                 handler(responseObject.result.value, nil)
+                return
             }
             if responseObject.result.isFailure {
                 handler(nil, responseObject.result.error)
+                return
             }
         }
     }
@@ -43,11 +47,13 @@ public class AgsHttpRequest: AgsHttpRequestProtocol {
     public func put(_ url: String, body: [String: Any]? = [:], headers: [String: String]? = [:], _ handler: @escaping (Any?, Error?) -> Void) {
         Alamofire.request(url, method: .put, parameters: body, encoding: JSONEncoding.default, headers: headers).responseJSON { (responseObject) -> Void in
 
-            if responseObject.result.isSuccess {
+            if self.isHTTPResponseSuccess(responseObject) {
                 handler(responseObject.result.value, nil)
+                return
             }
             if responseObject.result.isFailure {
                 handler(nil, responseObject.result.error)
+                return
             }
         }
     }
@@ -55,13 +61,22 @@ public class AgsHttpRequest: AgsHttpRequestProtocol {
     public func delete(_ url: String, headers: [String: String]? = [:], _ handler: @escaping (Any?, Error?) -> Void) {
         Alamofire.request(url, method: .delete, encoding: JSONEncoding.default, headers: headers).responseJSON { (responseObject) -> Void in
 
-            if responseObject.result.isSuccess {
+            if self.isHTTPResponseSuccess(responseObject) {
                 handler(responseObject.result.value, nil)
+                return
             }
             if responseObject.result.isFailure {
                 handler(nil, responseObject.result.error)
+                return
             }
         }
+    }
+    
+    /**
+     Check whether a response is successful.
+    */
+    private func isHTTPResponseSuccess(_ responseObject: DataResponse<Any>) -> Bool {
+        return responseObject.result.isSuccess || (200..<300).contains(responseObject.response?.statusCode ?? 0)
     }
 }
 


### PR DESCRIPTION
### Motivation

https://github.com/aerogear/aerogear-ios-sdk/issues/44


## Progress

I have tried worked on top of raw status message check that was covering many cases where status code was ok but json were not parsable.

We have tested case to get raw response. 

## Status

Implemented error handling alternative: https://github.com/aerogear/aerogear-ios-sdk/pull/43

Issue upstream (however this may be expected behavior and we will get that rejected) https://github.com/Alamofire/Alamofire/issues/2466

## Notes

If we are not happy to get that wrapper in core we could do the same error handling in keycloak to detect if error is empty content and skip that for login method. 
@aidenkeating  Leaving up to you what will be more suitable aproach.