### PR TITLE
Replace timestamp Int converter to NSString format

### DIFF
--- a/modules/core/metrics/AgsMetrics.swift
+++ b/modules/core/metrics/AgsMetrics.swift
@@ -61,7 +61,7 @@ open class AgsMetrics: MetricsPublishable {
     private func appendToRootMetrics(_ payload: MetricsData) -> [String: Any] {
         return [
             "clientId": appData.clientId,
-            "timestamp": NSString(format: "%.0f", (NSDate().timeIntervalSince1970 * 1000)),
+            "timestamp": UInt64(NSDate().timeIntervalSince1970 * 1000),
             "data": payload
         ]
     }

--- a/modules/core/metrics/AgsMetrics.swift
+++ b/modules/core/metrics/AgsMetrics.swift
@@ -61,7 +61,7 @@ open class AgsMetrics: MetricsPublishable {
     private func appendToRootMetrics(_ payload: MetricsData) -> [String: Any] {
         return [
             "clientId": appData.clientId,
-            "timestamp": Int(NSDate().timeIntervalSince1970 * 1000),
+            "timestamp": NSString(format: "%.0f", (NSDate().timeIntervalSince1970 * 1000)),
             "data": payload
         ]
     }


### PR DESCRIPTION
Convert Double in Int to remove the decimal part cause an exception in some cases

> Fatal error: Double value cannot be converted to Int because the result would be greater than Int.max

Related issues: 

* [AGIOS-681](https://issues.jboss.org/browse/AGIOS-681)