### PR TITLE
docs: example app guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ AeroGear Services IOS Swift SDK (AGS)
 
 1. [End User Getting Started Guide](./docs/getting-started.adoc)
 1. [Service Contributor Guide](./docs/service-guide.adoc)
-1. [Example App Guide](./docs/example-app-guide.adoc)
 
 ### List of SDKs
 
@@ -21,7 +20,9 @@ Mobile application Metrics SDK (part of the core bundle)
 
 ## Contributing
 
-See [General Contributing Guide](./CONTRIBUTING.md)
+[General Contributing Guide](./CONTRIBUTING.md)
+
+[Example Application Guide](./example/README.adoc)
 
 ## License
 

--- a/example/README.adoc
+++ b/example/README.adoc
@@ -1,4 +1,7 @@
-= End user documentation
+= Example project
+
+**This project is used only for internal testing purposes**
+See official documentation to see how to integrate SDK into your app.
 
 == Prerequisites
 
@@ -48,4 +51,6 @@ In the Xcode workspace, you will see a file explorer similar to that below:
 image:./images/example-app-workspace.png[]
 
 Under `Pods` > `Development Pods` you will find the Core and the Metrics SDKs.
+
+
 


### PR DESCRIPTION
## Motivation

Following suggestions on the email list example application should not be included into the public docs.

## Tasks 

- [x] Moved guide out of official documentation.
- [x] Added example guide to contribution section.