### PR TITLE
Allow arrays and dictionary in config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "9.0"
+      xcode: "9.3.0"
     shell: /bin/bash --login -eo pipefail
     steps:
       - checkout
@@ -50,7 +50,7 @@ jobs:
           working_directory: ./example
           command: fastlane scan
           environment:
-            SCAN_DEVICE: iPhone 6
+            SCAN_DEVICE: iPhone 7
             SCAN_SCHEME: AeroGearSdkExample
 
       # Collect XML test results data to show in the UI,
@@ -63,4 +63,4 @@ jobs:
           destination: scan-test-results
       - store_artifacts:
           path: ~/Library/Logs/scan
-          destination: scan-logs
+          destination: scan-logs      

--- a/example/AeroGearSdkExample/home/HomeViewController.swift
+++ b/example/AeroGearSdkExample/home/HomeViewController.swift
@@ -60,14 +60,7 @@ class HomeViewController: UIViewController, UIPickerViewDataSource, UIPickerView
     func pickerView(_: UIPickerView, didSelectRow row: Int, inComponent _: Int) {
         AgsCore.logger.info("Loading configuration")
         currentConfig = AgsCore.instance.getConfiguration(pickerDataSource[row])
-        let jsonEncoder = JSONEncoder()
-        do {
-            let jsonData = try jsonEncoder.encode(currentConfig)
-            let jsonString = String(data: jsonData, encoding: .utf8)
-            AgsCore.logger.debug("JSON String \(jsonString ?? "")")
-            config.text = jsonString
-        } catch {
-        }
+        config.text = currentConfig?.getDescription()
     }
 
     override func didReceiveMemoryWarning() {

--- a/example/AeroGearSdkExampleTests/core/MobileServiceTest.swift
+++ b/example/AeroGearSdkExampleTests/core/MobileServiceTest.swift
@@ -17,7 +17,7 @@ class MobileServiceTest: XCTestCase {
     static let configBool = true
     static let configDouble: Double = 2.1
     static let configDouble2: Double = 2.0
-    static let arrayValues = [1];
+    static let arrayValues = [1]
     let mobileServiceData = """
     {
         "id": "\(example)",
@@ -54,7 +54,7 @@ class MobileServiceTest: XCTestCase {
         XCTAssertEqual(mobileServiceToTest!.name, MobileServiceTest.exampleService)
         XCTAssertEqual(mobileServiceToTest!.url, MobileServiceTest.exampleUrl)
     }
-    
+
     func testParseTypes() {
         let serviceConfig = mobileServiceToTest!.config!
         XCTAssertEqual(serviceConfig["string"]!.getString()!, MobileServiceTest.configString)
@@ -63,16 +63,16 @@ class MobileServiceTest: XCTestCase {
         XCTAssertEqual(serviceConfig["double"]!.getDouble()!, MobileServiceTest.configDouble)
         XCTAssertEqual(serviceConfig["double2"]!.getDouble()!, MobileServiceTest.configDouble2)
     }
-    
+
     func testParseNestedObj() {
         let serviceConfig = mobileServiceToTest!.config!
-        let nestedObject = serviceConfig["nestedObject"]?.getObject();
+        let nestedObject = serviceConfig["nestedObject"]?.getObject()
         XCTAssertNotNil(nestedObject)
     }
-    
+
     func testParseArray() {
         let serviceConfig = mobileServiceToTest!.config!
-        let array = serviceConfig["array"]!.getArray()!;
+        let array = serviceConfig["array"]!.getArray()!
         XCTAssertEqual(array[0].getInt(), MobileServiceTest.arrayValues[0])
     }
 }

--- a/example/AeroGearSdkExampleTests/core/MobileServiceTest.swift
+++ b/example/AeroGearSdkExampleTests/core/MobileServiceTest.swift
@@ -16,8 +16,8 @@ class MobileServiceTest: XCTestCase {
     static let configInt = 1
     static let configBool = true
     static let configDouble: Double = 2.1
-    static let configAnotherDouble: Double = 2.0
-
+    static let configAnotherDouble: Double = 2.7
+    static let arrayValues = [1];
     let mobileServiceData = """
     {
         "id": "\(example)",
@@ -29,7 +29,10 @@ class MobileServiceTest: XCTestCase {
             "int": \(configInt),
             "bool": \(configBool),
             "double": \(configDouble),
-            "double2": \(configAnotherDouble)
+            "object": {
+                "double2": \(configAnotherDouble)
+            },
+            "array": \(arrayValues)
         }
     }
     """.data(using: .utf8)!
@@ -38,18 +41,14 @@ class MobileServiceTest: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
         mobileServiceToTest = try? JSONDecoder().decode(MobileService.self, from: mobileServiceData)
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
 
     func testParse() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
         XCTAssertEqual(mobileServiceToTest!.id, MobileServiceTest.example)
         XCTAssertEqual(mobileServiceToTest!.type, MobileServiceTest.exampleType)
         XCTAssertEqual(mobileServiceToTest!.name, MobileServiceTest.exampleService)
@@ -59,6 +58,16 @@ class MobileServiceTest: XCTestCase {
         XCTAssertEqual(serviceConfig["int"]!.getInt()!, MobileServiceTest.configInt)
         XCTAssertEqual(serviceConfig["bool"]!.getBool()!, MobileServiceTest.configBool)
         XCTAssertEqual(serviceConfig["double"]!.getDouble()!, MobileServiceTest.configDouble)
-        XCTAssertEqual(serviceConfig["double2"]!.getDouble()!, MobileServiceTest.configAnotherDouble)
+    }
+    
+    func testParseNested() {
+        let serviceConfig = mobileServiceToTest!.config!
+        // Nested config
+        let nestedObject = serviceConfig["object"]!.getObject();
+        let double2 = nestedObject!["double2"]!
+        XCTAssertEqual(double2.getDouble()!, MobileServiceTest.configAnotherDouble)
+        let array = serviceConfig["array"]!.getArray()!;
+        XCTAssertEqual(array[0].getInt(),MobileServiceTest.arrayValues[0])
+        
     }
 }

--- a/example/AeroGearSdkExampleTests/core/MobileServiceTest.swift
+++ b/example/AeroGearSdkExampleTests/core/MobileServiceTest.swift
@@ -16,7 +16,7 @@ class MobileServiceTest: XCTestCase {
     static let configInt = 1
     static let configBool = true
     static let configDouble: Double = 2.1
-    static let configAnotherDouble: Double = 2.7
+    static let configDouble2: Double = 2.0
     static let arrayValues = [1];
     let mobileServiceData = """
     {
@@ -29,8 +29,8 @@ class MobileServiceTest: XCTestCase {
             "int": \(configInt),
             "bool": \(configBool),
             "double": \(configDouble),
-            "object": {
-                "double2": \(configAnotherDouble)
+            "double2": \(configDouble2),
+            "nestedObject": {
             },
             "array": \(arrayValues)
         }
@@ -53,21 +53,26 @@ class MobileServiceTest: XCTestCase {
         XCTAssertEqual(mobileServiceToTest!.type, MobileServiceTest.exampleType)
         XCTAssertEqual(mobileServiceToTest!.name, MobileServiceTest.exampleService)
         XCTAssertEqual(mobileServiceToTest!.url, MobileServiceTest.exampleUrl)
+    }
+    
+    func testParseTypes() {
         let serviceConfig = mobileServiceToTest!.config!
         XCTAssertEqual(serviceConfig["string"]!.getString()!, MobileServiceTest.configString)
         XCTAssertEqual(serviceConfig["int"]!.getInt()!, MobileServiceTest.configInt)
         XCTAssertEqual(serviceConfig["bool"]!.getBool()!, MobileServiceTest.configBool)
         XCTAssertEqual(serviceConfig["double"]!.getDouble()!, MobileServiceTest.configDouble)
+        XCTAssertEqual(serviceConfig["double2"]!.getDouble()!, MobileServiceTest.configDouble2)
     }
     
-    func testParseNested() {
+    func testParseNestedObj() {
         let serviceConfig = mobileServiceToTest!.config!
-        // Nested config
-        let nestedObject = serviceConfig["object"]!.getObject();
-        let double2 = nestedObject!["double2"]!
-        XCTAssertEqual(double2.getDouble()!, MobileServiceTest.configAnotherDouble)
+        let nestedObject = serviceConfig["nestedObject"]?.getObject();
+        XCTAssertNotNil(nestedObject)
+    }
+    
+    func testParseArray() {
+        let serviceConfig = mobileServiceToTest!.config!
         let array = serviceConfig["array"]!.getArray()!;
-        XCTAssertEqual(array[0].getInt(),MobileServiceTest.arrayValues[0])
-        
+        XCTAssertEqual(array[0].getInt(), MobileServiceTest.arrayValues[0])
     }
 }

--- a/modules/auth/User.swift
+++ b/modules/auth/User.swift
@@ -23,8 +23,8 @@ struct UserRole: Hashable {
     let roleName: String
     /** the type of the role */
     var roleType: Types {
-        if let ns = nameSpace {
-            if ns.isEmpty {
+        if let nspace = nameSpace {
+            if nspace.isEmpty {
                 return Types.REALM
             } else {
                 return Types.CLIENT
@@ -35,8 +35,8 @@ struct UserRole: Hashable {
     }
 
     var hashValue: Int {
-        if let ns = nameSpace {
-            return ns.hashValue ^ roleName.hashValue
+        if let nspace = nameSpace {
+            return nspace.hashValue ^ roleName.hashValue
         } else {
             return roleName.hashValue
         }

--- a/modules/auth/config/KeycloakConfig.swift
+++ b/modules/auth/config/KeycloakConfig.swift
@@ -41,9 +41,22 @@ class KeycloakConfig {
     init(_ mobileService: MobileService, _ authConfig: AuthenticationConfig) {
         self.authConfig = authConfig
         rawConfig = mobileService
-        serverUrl = (mobileService.config![serverUrlName]?.getString())!
-        realmId = (mobileService.config![realmIdName]?.getString())!
-        clientId = (mobileService.config![clientIdName]?.getString())!
+        guard let config = mobileService.config else {
+            AgsCore.logger.error("Missing keycloak configuration");
+            return;
+        }
+        
+        if let url = config[serverUrlName] {
+            serverUrl = url.getString() ?? "";
+        }
+        
+        if let realm = config[realmIdName] {
+            realmId = realm.getString() ?? "";
+        }
+        
+        if let clientIdValue = config[clientIdName] {
+            clientId = clientIdValue.getString() ?? "";
+        }
         baseUrl = String(format: baseUrlTemplate, serverUrl, realmId)
     }
 

--- a/modules/auth/config/KeycloakConfig.swift
+++ b/modules/auth/config/KeycloakConfig.swift
@@ -42,20 +42,20 @@ class KeycloakConfig {
         self.authConfig = authConfig
         rawConfig = mobileService
         guard let config = mobileService.config else {
-            AgsCore.logger.error("Missing keycloak configuration");
-            return;
+            AgsCore.logger.error("Missing keycloak configuration")
+            return
         }
-        
+
         if let url = config[serverUrlName] {
-            serverUrl = url.getString() ?? "";
+            serverUrl = url.getString() ?? ""
         }
-        
+
         if let realm = config[realmIdName] {
-            realmId = realm.getString() ?? "";
+            realmId = realm.getString() ?? ""
         }
-        
+
         if let clientIdValue = config[clientIdName] {
-            clientId = clientIdValue.getString() ?? "";
+            clientId = clientIdValue.getString() ?? ""
         }
         baseUrl = String(format: baseUrlTemplate, serverUrl, realmId)
     }

--- a/modules/core/config/MobileConfig.swift
+++ b/modules/core/config/MobileConfig.swift
@@ -132,6 +132,8 @@ public enum JSONValue: Decodable {
         switch self {
         case let .double(value):
             return value;
+        case let .int(value):
+            return Double(value);
         default:
             break;
         }

--- a/modules/core/config/MobileConfig.swift
+++ b/modules/core/config/MobileConfig.swift
@@ -3,7 +3,7 @@ import Foundation
 /**
  Model for mobile backend configuration
  */
-public struct MobileConfig: Codable {
+public struct MobileConfig: Decodable {
     // Version of configuration
     public let version: Int?
     // Name of the mobile client used to generate this config
@@ -20,91 +20,122 @@ public struct MobileConfig: Codable {
  Backend service model containing configuration
  Represents individual service metadata
  */
-public struct MobileService: Codable {
+public struct MobileService: Decodable {
     /** Unique id for service */
     public let id: String
     public let name: String
     public let type: String
     public let url: String
     public let config: [String: JSONValue]? //we can't use [String:Any] here as it is not conform to the Codable protocol
+    
+    /**
+     Get string with information about mobile service
+    */
+    public func getDescription() -> String {
+        return "id: \(id) \nname: \(name) \nurl: \(url) "
+    };
+
 }
 
-/**
- Represents dynamic values for configuration
- */
-public class JSONValue: Codable {
-    var rawValue: Any?
+extension Optional {
+    func resolve(with error: @autoclosure () -> Error) throws -> Wrapped {
+        switch self {
+        case .none: throw error()
+        case .some(let wrapped): return wrapped
+        }
+    }
+    
+    func or(_ other: Optional) -> Optional {
+        switch self {
+        case .none: return other
+        case .some: return self
+        }
+    }
+}
 
-    public required init(from decoder: Decoder) throws {
+public enum JSONValue: Decodable {
+    case string(String)
+    case int(Int)
+    case bool(Bool)
+    case double(Double)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    
+    public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        //the order here is important. An integer can be casted to double, and sometimes vice-versa (e.g 1.0 -> 1). So integer needs to be checked first.
-        if let value = try? container.decode(Bool.self) {
-            rawValue = value
-        } else if let value = try? container.decode(Int.self) {
-            rawValue = value
-        } else if let value = try? container.decode(Double.self) {
-            rawValue = value
-        } else if let value = try? container.decode(String.self) {
-            rawValue = value
-        }
+        self = try ((try? container.decode(String.self)).map(JSONValue.string))
+            .or((try? container.decode(Int.self)).map(JSONValue.int))
+            .or((try? container.decode(Double.self)).map(JSONValue.double))
+            .or((try? container.decode(Bool.self)).map(JSONValue.bool))
+            .or((try? container.decode([String: JSONValue].self)).map(JSONValue.object))
+            .or((try? container.decode([JSONValue].self)).map(JSONValue.array))
+            .resolve(with: DecodingError.typeMismatch(JSONValue.self, DecodingError.Context(codingPath: container.codingPath, debugDescription: "Not a JSON")))
     }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        if let boolValue = getBool() {
-            try container.encode(boolValue)
-        } else if let intValue = getInt() {
-            try container.encode(intValue)
-        } else if let doubleValue = getDouble() {
-            try container.encode(doubleValue)
-        } else if let stringValue = getString() {
-            try container.encode(stringValue)
-        }
-    }
-
-    /**
-     Return the string value
-     - returns: a string if the value is a valid string, otherwise nil
-     */
+    
+    // Fetch string
     public func getString() -> String? {
-        if let stringValue = rawValue as? String {
-            return stringValue
+        switch self {
+        case let .string(value):
+            return value;
+        default:
+            break;
         }
-        return nil
+        return nil;
     }
-
-    /**
-     Return the integer value
-     - returns: an integer if the value is a valid integer, otherwise nil
-     */
+    
+    // Fetch Int
     public func getInt() -> Int? {
-        if let intValue = rawValue as? Int {
-            return intValue
+        switch self {
+        case let .int(value):
+            return value;
+        default:
+            break;
         }
-        return nil
+         return nil;
     }
-
-    /**
-     Return the boolean value
-     - returns: a boolean if the value is a valid boolean, otherwise nil
-     */
+    
+    // Fetch Bool
     public func getBool() -> Bool? {
-        if let boolValue = rawValue as? Bool {
-            return boolValue
+        switch self {
+        case let .bool(value):
+            return value;
+        default:
+            break;
         }
-        return nil
+        return nil;
     }
-
-    /**
-     Return the double value
-     - returns: a double if the value is a valid double or integer, otherwise nil
-     */
+    
+    // Fetch object (dictionary)
+    public func getObject() -> [String: JSONValue]? {
+        switch self {
+        case let .object(value):
+            return value;
+        default:
+            break;
+        }
+        return nil;
+    }
+    
+    // Fetch Array
+    public func getArray() -> [JSONValue]? {
+        switch self {
+        case let .array(value):
+            return value;
+        default:
+            break;
+        }
+        return nil;
+    }
+    
+    // Fetch double
     public func getDouble() -> Double? {
-        if let doubleValue = rawValue as? Double {
-            return doubleValue
-        } else if let intValue = rawValue as? Int {
-            return Double(intValue)
+        switch self {
+        case let .double(value):
+            return value;
+        default:
+            break;
         }
-        return nil
+        return nil;
     }
+    
 }

--- a/modules/core/config/MobileConfig.swift
+++ b/modules/core/config/MobileConfig.swift
@@ -27,24 +27,23 @@ public struct MobileService: Decodable {
     public let type: String
     public let url: String
     public let config: [String: JSONValue]? //we can't use [String:Any] here as it is not conform to the Codable protocol
-    
+
     /**
      Get string with information about mobile service
     */
     public func getDescription() -> String {
         return "id: \(id) \nname: \(name) \nurl: \(url) "
-    };
-
+    }
 }
 
 extension Optional {
     func resolve(with error: @autoclosure () -> Error) throws -> Wrapped {
         switch self {
         case .none: throw error()
-        case .some(let wrapped): return wrapped
+        case let .some(wrapped): return wrapped
         }
     }
-    
+
     func or(_ other: Optional) -> Optional {
         switch self {
         case .none: return other
@@ -60,7 +59,7 @@ public enum JSONValue: Decodable {
     case double(Double)
     case object([String: JSONValue])
     case array([JSONValue])
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         self = try ((try? container.decode(String.self)).map(JSONValue.string))
@@ -71,73 +70,72 @@ public enum JSONValue: Decodable {
             .or((try? container.decode([JSONValue].self)).map(JSONValue.array))
             .resolve(with: DecodingError.typeMismatch(JSONValue.self, DecodingError.Context(codingPath: container.codingPath, debugDescription: "Not a JSON")))
     }
-    
+
     // Fetch string
     public func getString() -> String? {
         switch self {
         case let .string(value):
-            return value;
+            return value
         default:
-            break;
+            break
         }
-        return nil;
+        return nil
     }
-    
+
     // Fetch Int
     public func getInt() -> Int? {
         switch self {
         case let .int(value):
-            return value;
+            return value
         default:
-            break;
+            break
         }
-         return nil;
+        return nil
     }
-    
+
     // Fetch Bool
     public func getBool() -> Bool? {
         switch self {
         case let .bool(value):
-            return value;
+            return value
         default:
-            break;
+            break
         }
-        return nil;
+        return nil
     }
-    
+
     // Fetch object (dictionary)
     public func getObject() -> [String: JSONValue]? {
         switch self {
         case let .object(value):
-            return value;
+            return value
         default:
-            break;
+            break
         }
-        return nil;
+        return nil
     }
-    
+
     // Fetch Array
     public func getArray() -> [JSONValue]? {
         switch self {
         case let .array(value):
-            return value;
+            return value
         default:
-            break;
+            break
         }
-        return nil;
+        return nil
     }
-    
+
     // Fetch double
     public func getDouble() -> Double? {
         switch self {
         case let .double(value):
-            return value;
+            return value
         case let .int(value):
-            return Double(value);
+            return Double(value)
         default:
-            break;
+            break
         }
-        return nil;
+        return nil
     }
-    
 }

--- a/modules/push/AgsPush.swift
+++ b/modules/push/AgsPush.swift
@@ -47,10 +47,10 @@ public class AgsPush {
      - parameter failure: A block object to be executed when the registration operation finishes unsuccessfully.This block has no return value and takes one argument: The `Error` object describing the error that occurred during the registration process.
     */
     public func register(_ deviceToken: Data,
-                  _ config: UnifiedPushConfig,
-                  _ credentials: UnifiedPushCredentials,
-                  success: @escaping (() -> Void),
-                  failure: @escaping ((Error) -> Void)) {
+                         _ config: UnifiedPushConfig,
+                         _ credentials: UnifiedPushCredentials,
+                         success: @escaping (() -> Void),
+                         failure: @escaping ((Error) -> Void)) {
 
         let currentDevice = UIDevice()
 
@@ -70,7 +70,7 @@ public class AgsPush {
             guard let requestError = response.error else {
                 self.saveClientDeviceInformation(deviceToken, self.serverURL)
                 success()
-                return; 
+                return
             }
             failure(requestError)
         })
@@ -94,8 +94,8 @@ public class AgsPush {
     fileprivate func convertToString(_ deviceToken: Data?) -> String? {
         if let token = (deviceToken as NSData?)?.description {
             return token.replacingOccurrences(of: "<", with: "")
-                    .replacingOccurrences(of: ">", with: "")
-                    .replacingOccurrences(of: " ", with: "")
+                .replacingOccurrences(of: ">", with: "")
+                .replacingOccurrences(of: " ", with: "")
         }
         return nil
     }

--- a/modules/push/AgsPush.swift
+++ b/modules/push/AgsPush.swift
@@ -44,13 +44,13 @@ public class AgsPush {
 
      - parameter success: A block object to be executed when the registration operation finishes successfully. This block has no return value.
 
-     - parameter failure: A block object to be executed when the registration operation finishes unsuccessfully.This block has no return value and takes one argument: The `NSError` object describing the error that occurred during the registration process.
+     - parameter failure: A block object to be executed when the registration operation finishes unsuccessfully.This block has no return value and takes one argument: The `Error` object describing the error that occurred during the registration process.
     */
     public func register(_ deviceToken: Data,
-                         _ config: UnifiedPushConfig,
-                         _ credentials: UnifiedPushCredentials,
-                         success: @escaping (() -> Void),
-                         failure: @escaping ((NSError) -> Void)) {
+                  _ config: UnifiedPushConfig,
+                  _ credentials: UnifiedPushCredentials,
+                  success: @escaping (() -> Void),
+                  failure: @escaping ((Error) -> Void)) {
 
         let currentDevice = UIDevice()
 
@@ -66,14 +66,14 @@ public class AgsPush {
         ] as [String: Any]
 
         let registerUrl = self.serverURL.appendingPathComponent(AgsPush.apiPath).absoluteString
-        self.requestApi.post(registerUrl, body: postData, headers: headers) { (response) -> Void in
-            if let error = response.error {
-                failure(error as NSError)
-                return
+        self.requestApi.post(registerUrl, body: postData, headers: headers, { response in
+            guard let requestError = response.error else {
+                self.saveClientDeviceInformation(deviceToken, self.serverURL)
+                success()
+                return; 
             }
-            self.saveClientDeviceInformation(deviceToken, self.serverURL)
-            success()
-        }
+            failure(requestError)
+        })
     }
 
     // Storing data in UserDefaults
@@ -94,8 +94,8 @@ public class AgsPush {
     fileprivate func convertToString(_ deviceToken: Data?) -> String? {
         if let token = (deviceToken as NSData?)?.description {
             return token.replacingOccurrences(of: "<", with: "")
-                .replacingOccurrences(of: ">", with: "")
-                .replacingOccurrences(of: " ", with: "")
+                    .replacingOccurrences(of: ">", with: "")
+                    .replacingOccurrences(of: " ", with: "")
         }
         return nil
     }

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -8,5 +8,12 @@
 
 set -eo pipefail
 
+
+## Correct files 
+
 swiftlint autocorrect
 swiftformat --disable trailingCommas,redundantSelf,unusedArguments --comments ignore --indent 4 . 
+
+## Check if passing
+
+swiftlint


### PR DESCRIPTION
### Motivation

Allow to support arrays and nested objects in config. 
Follow the recommended patterns when decoding json to unknown type.