### PR TITLE
Use config id for fetching config

### DIFF
--- a/modules/core/config/ServiceConfig.swift
+++ b/modules/core/config/ServiceConfig.swift
@@ -53,7 +53,7 @@ public class ServiceConfig {
      */
     public func getConfiguration(_ serviceRef: String) -> [MobileService] {
         if let config = config {
-            return config.services.filter { $0.name == serviceRef }
+            return config.services.filter { $0.id == serviceRef }
         } else {
             return []
         }


### PR DESCRIPTION
### Motivation

Use `id` field from config instead of `name`.
While change is breaking compatibility, it doesn't impact any current services as id and names are the same. 