### PR TITLE
fix: add config by type

### DIFF
--- a/docs/metrics/extending-metrics.adoc
+++ b/docs/metrics/extending-metrics.adoc
@@ -36,4 +36,3 @@ MyPublisher publisher: MetricsPublisher = MyPublisher()
 AgsCore.instance.getMetrics().setMetricsPublisher(publisher) 
 ----
 
-

--- a/example/AeroGearSdkExampleTests/core/ServiceConfigTests.swift
+++ b/example/AeroGearSdkExampleTests/core/ServiceConfigTests.swift
@@ -28,4 +28,13 @@ class ServiceConfigTests: XCTestCase {
     func testConfigParsingInValidService() {
         XCTAssertNil(config[invalidServiceName])
     }
+    
+    
+    func testConfigParsingGetById() {
+        XCTAssertNotNil(config.getConfigurationById(validServiceName))
+    }
+    
+    func testConfigParsingGetByIdInvalid() {
+        XCTAssertNil(config.getConfigurationById(invalidServiceName))
+    }
 }

--- a/example/AeroGearSdkExampleTests/core/ServiceConfigTests.swift
+++ b/example/AeroGearSdkExampleTests/core/ServiceConfigTests.swift
@@ -22,11 +22,11 @@ class ServiceConfigTests: XCTestCase {
     }
 
     func testConfigReading() {
-        XCTAssertNotNil(config[validServiceName])
+        XCTAssertNotNil(config.getConfigurationByType(validServiceName))
     }
 
     func testConfigParsingInValidService() {
-        XCTAssertNil(config[invalidServiceName])
+        XCTAssertTrue(config.getConfigurationByType(invalidServiceName).count == 0)
     }
     
     

--- a/modules/core/AgsCore.swift
+++ b/modules/core/AgsCore.swift
@@ -26,12 +26,19 @@ public class AgsCore {
      - parameter serviceType:  service type that will be used to fetch configuration
      */
     public func getConfiguration(_ serviceType: String) -> MobileService? {
-        return config.getConfigurationByType(serviceType).first
+        let configuration = config.getConfigurationByType(serviceType)
+        if configuration.count > 1 {
+            AgsCore.logger.warning("""
+             Config contains more than one service of the same type.
+             Using configuration from the first occurence of service with that type.
+            """)
+        }
+        return configuration.first
     }
-    
+
     /**
      Get configuration for specific service reference
-     
+
      - returns: MobileService instance or nil if configuration is missing service of that type
      - parameter serviceId: id that will be used to fetch configuration
      */

--- a/modules/core/AgsCore.swift
+++ b/modules/core/AgsCore.swift
@@ -20,13 +20,23 @@ public class AgsCore {
     }
 
     /**
-     Get configuration for specific service reference
+     Get single configuration for specific service type
 
      - returns: MobileService instance or nil if configuration is missing service of that type
-     - parameter serviceRef: unique service reference uset to fetch configuration
+     - parameter serviceType:  service type that will be used to fetch configuration
      */
-    public func getConfiguration(_ serviceRef: String) -> MobileService? {
-        return config[serviceRef]
+    public func getConfiguration(_ serviceType: String) -> MobileService? {
+        return config.getConfigurationByType(serviceType).first
+    }
+    
+    /**
+     Get configuration for specific service reference
+     
+     - returns: MobileService instance or nil if configuration is missing service of that type
+     - parameter serviceId: id that will be used to fetch configuration
+     */
+    public func getConfigurationById(_ serviceId: String) -> MobileService? {
+        return config.getConfigurationById(serviceId)
     }
 
     /**

--- a/modules/core/config/ServiceConfig.swift
+++ b/modules/core/config/ServiceConfig.swift
@@ -28,7 +28,7 @@ public class ServiceConfig {
      - return: MobileService instance or nil if service cannot be found
      */
     public subscript(serviceRef: String) -> MobileService? {
-        let configuration = getConfiguration(serviceRef)
+        let configuration = getConfigurationByType(serviceRef)
         if configuration.count > 1 {
             AgsCore.logger.warning("""
              Mobile configuration \(configFileName) contains more than one service of the same type.
@@ -49,14 +49,29 @@ public class ServiceConfig {
     /**
      Fetch configuration for specific type
 
+     - Parameter type: type of the service to fetch
      - return: MobileService array
      */
-    public func getConfiguration(_ serviceRef: String) -> [MobileService] {
+    public func getConfigurationByType(_ type: String) -> [MobileService] {
         if let config = config {
-            return config.services.filter { $0.id == serviceRef }
+            return config.services.filter { $0.type == type }
         } else {
             return []
         }
+    }
+
+    /**
+     Fetch configuration for specific id
+     Should be used for elements that can appear multiple times in the config
+
+     - Parameter id: unique id of the service
+     - return: MobileService
+     */
+    public func getConfigurationById(_ id: String) -> MobileService? {
+        if let config = config {
+            return config.services.first { $0.id == id }
+        }
+        return nil
     }
 
     private func readConfiguration() {

--- a/modules/core/config/ServiceConfig.swift
+++ b/modules/core/config/ServiceConfig.swift
@@ -23,30 +23,6 @@ public class ServiceConfig {
     }
 
     /**
-     Fetch single service configuration from configuration files.
-
-     - return: MobileService instance or nil if service cannot be found
-     */
-    public subscript(serviceRef: String) -> MobileService? {
-        let configuration = getConfigurationByType(serviceRef)
-        if configuration.count > 1 {
-            AgsCore.logger.warning("""
-             Mobile configuration \(configFileName) contains more than one service of the same type.
-             Using configuration from the first occurence of service with that type.
-             Any other duplicate will be ignored.
-             Please review your \(configFileName) for services with \(serviceRef) type.
-            """)
-        } else if configuration.count == 0 {
-            AgsCore.logger.error("""
-            Configuration  \(configFileName) is missing service \(serviceRef) configuration
-            Please review your \(configFileName) for services with \(serviceRef) type.
-            """)
-            return nil
-        }
-        return configuration.first
-    }
-
-    /**
      Fetch configuration for specific type
 
      - Parameter type: type of the service to fetch

--- a/modules/core/metrics/MetricsConfig.swift
+++ b/modules/core/metrics/MetricsConfig.swift
@@ -11,7 +11,8 @@ class MetricsConfig {
     public var config: MobileService?
 
     init(_ configService: ServiceConfig) {
-        if let serviceConfig = configService.getConfigurationByType(sdkId).first {
+        let serviceConfigs = configService.getConfigurationByType(sdkId)
+        if let serviceConfig = serviceConfigs.first {
             config = serviceConfig
         } else {
             AgsCore.logger.error("""

--- a/modules/core/metrics/MetricsConfig.swift
+++ b/modules/core/metrics/MetricsConfig.swift
@@ -11,7 +11,7 @@ class MetricsConfig {
     public var config: MobileService?
 
     init(_ configService: ServiceConfig) {
-        if let serviceConfig = configService[sdkId] {
+        if let serviceConfig = configService.getConfigurationByType(sdkId).first {
             config = serviceConfig
         } else {
             AgsCore.logger.error("""


### PR DESCRIPTION
## Motivation

Use type for fetching mobile configurations instead of name.
Name is just human readable name and it's not guaranteed to be unique.
