### PR TITLE
ci: allow any tag to kick off circle release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,6 @@ workflows:
             - build
           filters:
             tags:
-              only: /\d\.\d\.\d/
+              only: /.*/ # allow anything because tag syntax is validated as part of validate-release.sh
             branches:
               ignore: /.*/


### PR DESCRIPTION
I think that CircleCI doesn't really validate these tags very all. Relying on our own validation scripts is much better. It would be good to get this merged before https://github.com/aerogear/aerogear-ios-sdk/pull/128 just in case.