### PR TITLE
 🔧 the security result class should not contain the result text

### DIFF
--- a/modules/security/deviceTrust/SecurityCheckResult.swift
+++ b/modules/security/deviceTrust/SecurityCheckResult.swift
@@ -9,18 +9,15 @@ public struct SecurityCheckResult : Encodable{
     
     public let name: String
     public let passed: Bool
-    public var result: String
 
     /**
      - Initialise a SecurityCheckResult
      
      - Parameter name: the name of the check result
      - Parameter passed: whether or not the security check passed or failed
-     - Parameter result: a description of the result
      */
-    public init(_ name: String, _ passed: Bool, _ result: String) {
+    public init(_ name: String, _ passed: Bool) {
         self.name = name
         self.passed = passed
-        self.result = result
     }
 }

--- a/modules/security/deviceTrust/checks/DeviceLockCheck.swift
+++ b/modules/security/deviceTrust/checks/DeviceLockCheck.swift
@@ -18,10 +18,6 @@ import LocalAuthentication
      */
     public func check() -> SecurityCheckResult {
         let deviceLockSet = LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: nil)
-        if deviceLockSet == false {
-            return SecurityCheckResult(self.name, false)
-        } else {
-            return SecurityCheckResult(self.name, true)
-        }
+        return SecurityCheckResult(self.name, deviceLockSet)
     }
 }

--- a/modules/security/deviceTrust/checks/DeviceLockCheck.swift
+++ b/modules/security/deviceTrust/checks/DeviceLockCheck.swift
@@ -8,8 +8,6 @@ import LocalAuthentication
  */
  public class DeviceLockCheck: SecurityCheck {
     public let name = "Device Lock check"
-    private let passing = "Device lock detected"
-    private let failing = "Device lock not detected"
 
     public init() {}
 
@@ -21,9 +19,9 @@ import LocalAuthentication
     public func check() -> SecurityCheckResult {
         let deviceLockSet = LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: nil)
         if deviceLockSet == false {
-            return SecurityCheckResult(self.name, false, self.failing)
+            return SecurityCheckResult(self.name, false)
         } else {
-            return SecurityCheckResult(self.name, true, self.passing)
+            return SecurityCheckResult(self.name, true)
         }
     }
 }

--- a/modules/security/deviceTrust/checks/NonDebugCheck.swift
+++ b/modules/security/deviceTrust/checks/NonDebugCheck.swift
@@ -16,10 +16,10 @@ public class NonDebugCheck: SecurityCheck {
      - Returns: A Security Check result with a true or false passing property
      */
     public func check() -> SecurityCheckResult {
+        var passed = true
         #if DEBUG
-            return SecurityCheckResult(self.name, false)
-        #else
-            return SecurityCheckResult(self.name, true)
+            passed = false
         #endif
+        return SecurityCheckResult(self.name, passed)
     }
 }

--- a/modules/security/deviceTrust/checks/NonDebugCheck.swift
+++ b/modules/security/deviceTrust/checks/NonDebugCheck.swift
@@ -7,8 +7,6 @@ import Foundation
  */
 public class NonDebugCheck: SecurityCheck {
     public var name = "Debugger check"
-    private let passing = "Debugger not detected"
-    private let failing = "Debugger detected"
 
     public init() {}
 
@@ -19,9 +17,9 @@ public class NonDebugCheck: SecurityCheck {
      */
     public func check() -> SecurityCheckResult {
         #if DEBUG
-            return SecurityCheckResult(self.name, false, self.failing)
+            return SecurityCheckResult(self.name, false)
         #else
-            return SecurityCheckResult(self.name, true, self.passing)
+            return SecurityCheckResult(self.name, true)
         #endif
     }
 }

--- a/modules/security/deviceTrust/checks/NonEmulatorCheck.swift
+++ b/modules/security/deviceTrust/checks/NonEmulatorCheck.swift
@@ -7,8 +7,6 @@ import Foundation
  */
  public class NonEmulatorCheck: SecurityCheck {
     public let name = "Emulator check"
-    private let passing = "Emulator not detected"
-    private let failing = "Emulator detected"
 
     public init() {}
 
@@ -19,8 +17,8 @@ import Foundation
      */
     public func check() -> SecurityCheckResult {
         #if (arch(i386) || arch(x86_64) && os(iOS))
-            return SecurityCheckResult(self.name, false, self.failing)
+            return SecurityCheckResult(self.name, false)
         #endif
-        return SecurityCheckResult(self.name, true, self.passing)
+        return SecurityCheckResult(self.name, true)
     }
 }

--- a/modules/security/deviceTrust/checks/NonEmulatorCheck.swift
+++ b/modules/security/deviceTrust/checks/NonEmulatorCheck.swift
@@ -16,9 +16,10 @@ import Foundation
      - Returns: A Security Check result with a true or false passing property
      */
     public func check() -> SecurityCheckResult {
+        var passed = true
         #if (arch(i386) || arch(x86_64) && os(iOS))
-            return SecurityCheckResult(self.name, false)
+            passed = false
         #endif
-        return SecurityCheckResult(self.name, true)
+        return SecurityCheckResult(self.name, passed)
     }
 }

--- a/modules/security/deviceTrust/checks/NonJailbrokenCheck.swift
+++ b/modules/security/deviceTrust/checks/NonJailbrokenCheck.swift
@@ -17,10 +17,6 @@ import Foundation
      - Returns: A Security Check result with a true or false passing property
      */
     public func check() -> SecurityCheckResult {
-        if DTTJailbreakDetection.isJailbroken() {
-            return SecurityCheckResult(self.name, false)
-        } else {
-            return SecurityCheckResult(self.name, true)
-        }
+        return SecurityCheckResult(self.name, !DTTJailbreakDetection.isJailbroken())
     }
 }

--- a/modules/security/deviceTrust/checks/NonJailbrokenCheck.swift
+++ b/modules/security/deviceTrust/checks/NonJailbrokenCheck.swift
@@ -8,8 +8,6 @@ import Foundation
  */
  public class NonJailbrokenCheck: SecurityCheck {
     public let name = "Jailbreak check"
-    private let passing = "Jailbreak not detected"
-    private let failing = "Jailbreak detected"
 
     public init() {}
 
@@ -20,9 +18,9 @@ import Foundation
      */
     public func check() -> SecurityCheckResult {
         if DTTJailbreakDetection.isJailbroken() {
-            return SecurityCheckResult(self.name, false, self.failing)
+            return SecurityCheckResult(self.name, false)
         } else {
-            return SecurityCheckResult(self.name, true, self.passing)
+            return SecurityCheckResult(self.name, true)
         }
     }
 }

--- a/tests/AeroGearSdkExample.xcodeproj/project.pbxproj
+++ b/tests/AeroGearSdkExample.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 				018FBE4F20123AEE00E763A5 /* Frameworks */,
 				018FBE5020123AEE00E763A5 /* Resources */,
 				1B2E2D2A6248F032BF93FB57 /* [CP] Embed Pods Frameworks */,
+				A05BEF2224EF50B751FBA656 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -380,6 +381,8 @@
 				018FBE6220123AEE00E763A5 /* Sources */,
 				018FBE6320123AEE00E763A5 /* Frameworks */,
 				018FBE6420123AEE00E763A5 /* Resources */,
+				914EA44BFDA3B60DA78F5CB8 /* [CP] Embed Pods Frameworks */,
+				493E7077E8339BE97AE73641 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -399,6 +402,8 @@
 				01AA3C99207CD5760096D2EE /* Sources */,
 				01AA3CAD207CD5760096D2EE /* Frameworks */,
 				01AA3CAF207CD5760096D2EE /* Resources */,
+				9900F056CF2AB85C806BAA56 /* [CP] Embed Pods Frameworks */,
+				D83FA05B92BC857FE30F374E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -589,6 +594,81 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		493E7077E8339BE97AE73641 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AeroGearSdkExampleTests/Pods-AeroGearSdkExampleTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		914EA44BFDA3B60DA78F5CB8 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AeroGearSdkExampleTests/Pods-AeroGearSdkExampleTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9900F056CF2AB85C806BAA56 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AeroGearSdkExampleIntegrationTests/Pods-AeroGearSdkExampleIntegrationTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A05BEF2224EF50B751FBA656 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AeroGearSdkExample/Pods-AeroGearSdkExample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D83FA05B92BC857FE30F374E /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-AeroGearSdkExampleIntegrationTests/Pods-AeroGearSdkExampleIntegrationTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
### Motivation

At the moment, the security check result class contains a string to describe the error messages. This should not be part of the SDK.

### Description

Remove the text description of the security check results.

### Progress

- [x] Done Task


@aidenkeating @danielpassos @StephenCoady  mind taking a look?