### PR TITLE
fix: runtime application crashes on auth

### DIFF
--- a/modules/auth/AgsAuth.swift
+++ b/modules/auth/AgsAuth.swift
@@ -94,10 +94,10 @@ open class AgsAuth {
      - throws: a `serviceNotConfigured` error if the Auth SDK has not been configured
      */
     public func login(presentingViewController: UIViewController, onCompleted: @escaping (_ user: User?, _ error: Error?) -> Void) throws {
-        guard configured else {
+        guard configured, let authenticator = authenticator else {
             throw Errors.serviceNotConfigured
         }
-        authenticator!.authenticate(presentingViewController: presentingViewController, onCompleted: onCompleted)
+        authenticator.authenticate(presentingViewController: presentingViewController, onCompleted: onCompleted)
     }
 
     /**
@@ -113,10 +113,10 @@ open class AgsAuth {
      - returns: true if the login process can be resumed, false otherwise
      */
     public func resumeAuth(url: URL) throws -> Bool {
-        guard configured else {
+        guard configured, let authenticator = authenticator else {
             throw Errors.serviceNotConfigured
         }
-        return authenticator!.resumeAuth(url: url)
+        return authenticator.resumeAuth(url: url)
     }
 
     /**
@@ -130,14 +130,16 @@ open class AgsAuth {
         a `noLoggedInUserError` if no user is logged in
      */
     public func logout(onCompleted: @escaping (_ error: Error?) -> Void) throws {
-        guard configured else {
+        guard configured, let authenticator = authenticator else {
             throw Errors.serviceNotConfigured
         }
-        if let currentUser = try? currentUser() {
-            authenticator!.logout(currentUser: currentUser!, onCompleted: onCompleted)
-        } else {
-            onCompleted(Errors.noLoggedInUserError)
+        do {
+            if let currentUser = try currentUser() {
+                authenticator.logout(currentUser: currentUser, onCompleted: onCompleted)
+                return
+            }
         }
+        onCompleted(Errors.noLoggedInUserError);
     }
 
     /**


### PR DESCRIPTION
### Please read this carefully!

General rule of thumb is to **NEVER** use `!` in swift unless we are sure that value was initialized. Using `!` to force unwrap optionals is sign of bad code. Optional variables are optional for this very purpose.

Mixing error handling and optionals is also not recommended. Optionals from try statement are different than optional that is being returned from method. For example:

```
guard let test = try? someMethod() else {
	print("test");
}
```

This will print `test` only when error is thrown.
If `someMethod` will return `nil` it will not be protected in guard.

### Motivation for this PR

Auth SDK library is causing numerous runtime crashes during normal usage.
I have fixed some most prominent.  

Example error:
![screen shot 2018-07-11 at 4 14 32 pm](https://user-images.githubusercontent.com/981838/42583629-422c4aae-8529-11e8-8e54-7a865818d0d6.png)

