### PR TITLE
Add new appauth external browser support

### DIFF
--- a/AGSAuth.podspec
+++ b/AGSAuth.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   ## Default core dependency
   s.dependency 'AGSCore', s.version.to_s
   ## Add other dependencies if needed
-  s.dependency 'AppAuth', '~> 0.92'
+  s.dependency 'AppAuth', '~> 0.93'
   s.dependency 'SwiftKeychainWrapper', '~> 3.0.1'
   s.dependency 'KTVJSONWebToken', '2.0.0'
   s.requires_arc = true

--- a/modules/auth/authenticator/OIDCAuthenticator.swift
+++ b/modules/auth/authenticator/OIDCAuthenticator.swift
@@ -82,8 +82,8 @@ public class OIDCAuthenticator: Authenticator {
         - error: the error returned in the `callback` function.  Will be nil if the token exchange was successful
      */
     func startAuthorizationFlow(byPresenting: OIDAuthorizationRequest, presenting: UIViewController, callback: @escaping (_ credentials: OIDCCredentials?, _ error: Error?) -> Void) -> OIDAuthorizationFlowSession {
-        
-        let flowCallback : OIDAuthStateAuthorizationCallback = { authState, error in
+
+        let flowCallback: OIDAuthStateAuthorizationCallback = { authState, error in
             if let state = authState {
                 if let err = state.authorizationError {
                     callback(nil, err)
@@ -93,17 +93,13 @@ public class OIDCAuthenticator: Authenticator {
             } else {
                 callback(nil, error)
             }
-        };
-        
-        if(authConfig.useExternalUserAgent){
-            let externalUserAgent = OIDExternalUserAgentIOSCustomBrowser.customBrowserSafari();
-            return OIDAuthState.authState(byPresenting: byPresenting,
-                                          externalUserAgent: externalUserAgent,
-                                          callback:flowCallback)
-        }else {
-             return OIDAuthState.authState(byPresenting: byPresenting,
-                                           presenting: presenting,
-                                           callback: flowCallback)
+        }
+
+        if authConfig.useExternalUserAgent {
+            let externalUserAgent = OIDExternalUserAgentIOSCustomBrowser.customBrowserSafari()
+            return OIDAuthState.authState(byPresenting: byPresenting, externalUserAgent: externalUserAgent, callback: flowCallback)
+        } else {
+            return OIDAuthState.authState(byPresenting: byPresenting, presenting: presenting, callback: flowCallback)
         }
     }
 

--- a/modules/auth/authenticator/OIDCAuthenticator.swift
+++ b/modules/auth/authenticator/OIDCAuthenticator.swift
@@ -82,7 +82,8 @@ public class OIDCAuthenticator: Authenticator {
         - error: the error returned in the `callback` function.  Will be nil if the token exchange was successful
      */
     func startAuthorizationFlow(byPresenting: OIDAuthorizationRequest, presenting: UIViewController, callback: @escaping (_ credentials: OIDCCredentials?, _ error: Error?) -> Void) -> OIDAuthorizationFlowSession {
-        return OIDAuthState.authState(byPresenting: byPresenting, presenting: presenting, callback: { authState, error in
+        
+        let flowCallback : OIDAuthStateAuthorizationCallback = { authState, error in
             if let state = authState {
                 if let err = state.authorizationError {
                     callback(nil, err)
@@ -92,7 +93,18 @@ public class OIDCAuthenticator: Authenticator {
             } else {
                 callback(nil, error)
             }
-        })
+        };
+        
+        if(authConfig.useExternalUserAgent){
+            let externalUserAgent = OIDExternalUserAgentIOSCustomBrowser.customBrowserSafari();
+            return OIDAuthState.authState(byPresenting: byPresenting,
+                                          externalUserAgent: externalUserAgent,
+                                          callback:flowCallback)
+        }else {
+             return OIDAuthState.authState(byPresenting: byPresenting,
+                                           presenting: presenting,
+                                           callback: flowCallback)
+        }
     }
 
     /**

--- a/modules/auth/config/AuthenticationConfig.swift
+++ b/modules/auth/config/AuthenticationConfig.swift
@@ -23,6 +23,6 @@ public struct AuthenticationConfig {
     public init(redirectURL: String, useExternalUserAgent: Bool = false, minTimeBetweenJwksRequests: UInt = 24 * 60) {
         self.redirectURL = URL(string: redirectURL)!
         self.minTimeBetweenJwksRequests = minTimeBetweenJwksRequests
-        self.useExternalUserAgent = useExternalUserAgent;
+        self.useExternalUserAgent = useExternalUserAgent
     }
 }

--- a/modules/auth/config/AuthenticationConfig.swift
+++ b/modules/auth/config/AuthenticationConfig.swift
@@ -7,9 +7,11 @@ import Foundation
 /** Configurations for the authentication service */
 public struct AuthenticationConfig {
     /** redirect url used during the authentication process */
-    let redirectURL: URL
+    public let redirectURL: URL
     /** the minimum time between making JWKS requests */
-    let minTimeBetweenJwksRequests: UInt
+    public let minTimeBetweenJwksRequests: UInt
+    /** Flag used to perform login in external browser instead of webview */
+    public let useExternalUserAgent: Bool
 
     /**
      Initialises the authentication configuration
@@ -18,8 +20,9 @@ public struct AuthenticationConfig {
         - redirectURL: the redirect URL for the developers app
         - minTimeBetweenJwksRequests: The minimum time, in minutes, between Json web key set requests. Default value is 1400 (1 day)
      */
-    public init(redirectURL: String, minTimeBetweenJwksRequests: UInt = 24 * 60) {
+    public init(redirectURL: String, useExternalUserAgent: Bool = false, minTimeBetweenJwksRequests: UInt = 24 * 60) {
         self.redirectURL = URL(string: redirectURL)!
         self.minTimeBetweenJwksRequests = minTimeBetweenJwksRequests
+        self.useExternalUserAgent = useExternalUserAgent;
     }
 }

--- a/modules/security/AgsSecurity.swift
+++ b/modules/security/AgsSecurity.swift
@@ -10,7 +10,6 @@ import Foundation
 public class AgsSecurity {
 
     private let serviceId = "security"
-    
 
     /**
      The initialise method of AgsSecurity

--- a/modules/sync/AgsSync.swift
+++ b/modules/sync/AgsSync.swift
@@ -1,31 +1,31 @@
-import Foundation
 import AGSCore
 import Apollo
+import Foundation
 
 /**
    AeroGear Services sync
  */
 public class AgsSync {
-    
+
     private let serviceName = "sync"
-    
+
     public static let instance: AgsSync = {
         let config = AgsCore.instance.getConfiguration(serviceName)
         let httpInterface = AgsCore.instance.getHttp()
         return AgsSync(config)
     }()
-   
+
     public static let instance = SyncService()
- 
+
     public let client: ApolloClient
 
     init(_ syncConfig: MobileService?) {
         self.serviceConfig = syncConfig
-        
+
         guard let url = syncConfig.url else {
-            return AgsCore.logger.error("Sync service is not configured");
+            return AgsCore.logger.error("Sync service is not configured")
         }
-  
+
         let configuration = URLSessionConfiguration.default
         let url = URL(string: url)!
         client = ApolloClient(networkTransport: HTTPNetworkTransport(url: url, configuration: configuration))


### PR DESCRIPTION
### Motivation

During the login SSO not always work immediately. 
Doing login in safari is usually recommended. 
I have added external browser support in order to perform more mobile friendly flow where login is happening in safari.
 
![](https://media.giphy.com/media/1xnu4yz7k2zYl0amrY/giphy.gif)

